### PR TITLE
🛳 Allow push to rubygems

### DIFF
--- a/determinator.gemspec
+++ b/determinator.gemspec
@@ -13,14 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/deliveroo/determinator"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    abort "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
Removes the gemspec block for pushing to Rubygems