### PR TITLE
💎 Prep for releases to rubygems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,22 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'semantic'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+namespace :version do
+  desc "Bumps the minor version of the gem, saving to the version file"
+  task :bump do
+    version = Semantic::Version.new(Determinator::VERSION)
+    # Always bump the patch version, the minor and major versions can be bumped manually
+    version.patch += 1
+
+    version_file = File.join(__dir__, "lib/determinator/version.rb")
+    vfile_contents = File.read(version_file)
+    new_contents = vfile_contents.sub('VERSION = "(.+?)"', %q[VERSION = "#{version.to_s}"])
+
+    File.write(version_file, new_contents)
+  end
+end

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,5 @@
+deployment:
+  release:
+    branch: master
+    commands:
+      - bundle exec rake version:bump release

--- a/determinator.gemspec
+++ b/determinator.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "routemaster-drain", "~> 2.5"
+  spec.add_runtime_dependency "routemaster-drain", "~> 2.4"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "guard-rspec", "~> 4.7"
   spec.add_development_dependency "factory_girl", "~> 4.8"
+  spec.add_development_dependency "semantic", "~> 1.6"
 end


### PR DESCRIPTION
- Adds new `rake version:bump` task for bumping the patch version within Circle CI
- Adds a `circle.yml` file so releases can occur from CI
- Changes the requirement of `routemaster-drain` so that it fits with other parts of our ecosystem.