### PR TITLE
Update routemaster drain dependency version

### DIFF
--- a/determinator.gemspec
+++ b/determinator.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "routemaster-drain", "~> 2.5"
+  spec.add_runtime_dependency "routemaster-drain", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This change bumps the version of routemaster-drain to 3.0. There is only
one change in the drain since the last version (2.5.4) and it is a
breaking change but determinator is not using the method that was
removed.

This is needed to allow me to update the routemaster-drain version in 
orderweb.

https://github.com/deliveroo/routemaster-drain/pull/54