### PR TITLE
Send the `active` attribute when initialising Feature

### DIFF
--- a/lib/determinator/retrieve/routemaster.rb
+++ b/lib/determinator/retrieve/routemaster.rb
@@ -43,6 +43,7 @@ module Determinator
           name:          obj.body.name,
           identifier:    obj.body.identifier,
           bucket_type:   obj.body.bucket_type,
+          active:        obj.body.active,
           target_groups: obj.body.target_groups.map { |tg|
             TargetGroup.new(
               rollout: tg.rollout,

--- a/spec/determinator/retrieve/routemaster_spec.rb
+++ b/spec/determinator/retrieve/routemaster_spec.rb
@@ -28,6 +28,7 @@ describe Determinator::Retrieve::Routemaster do
         name: feature_name,
         identifier: 'a',
         bucket_type: 'id',
+        active: true,
         target_groups: [
           {
             rollout: 32_768,


### PR DESCRIPTION
Fixes remaining problem with #18 where `active` from HATEOAS response for feature from Routemaster was not being passed to initialisation of local Feature PORO.