### PR TITLE
Honour the winning_variant

### DIFF
--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -101,6 +101,8 @@ module Determinator
     end
 
     def variant_for(feature, indicator)
+      return feature.winning_variant if feature.winning_variant
+
       # Scale up the weights so the variants fit within the possible space for the variant indicator
       variant_weight_total = feature.variants.values.reduce(:+)
       scale_factor = 65_535 / variant_weight_total.to_f

--- a/lib/determinator/feature.rb
+++ b/lib/determinator/feature.rb
@@ -3,15 +3,16 @@ module Determinator
   #
   # @attr_reader [nil,Hash<String,Integer>] variants The variants for this experiment, with the name of the variant as the key and the weight as the value. Will be nil for non-experiments.
   class Feature
-    attr_reader :name, :identifier, :bucket_type, :variants, :target_groups
+    attr_reader :name, :identifier, :bucket_type, :variants, :target_groups, :winning_variant
 
     BUCKET_TYPES = %i(id guid fallback)
 
-    def initialize(name:, identifier:, bucket_type:, target_groups:, variants: {}, overrides: {})
+    def initialize(name:, identifier:, bucket_type:, target_groups:, variants: {}, overrides: {}, winning_variant: nil)
       @name = name.to_s
       @identifier = identifier.to_s
       @variants = variants
       @target_groups = target_groups
+      @winning_variant = winning_variant
 
       @bucket_type = bucket_type.to_sym
       raise ArgumentError, "Unknown bucket type: #{bucket_type}" unless BUCKET_TYPES.include?(@bucket_type)

--- a/lib/determinator/retrieve/routemaster.rb
+++ b/lib/determinator/retrieve/routemaster.rb
@@ -52,7 +52,8 @@ module Determinator
           variants:      obj.body.variants.to_h,
           overrides:     obj.body.overrides.each_with_object({}) { |override, hash|
             hash[override.user_id] = override.variant
-          }
+          },
+          winning_variant: obj.body.winning_variant,
         )
       rescue ::Routemaster::Errors::ResourceNotFound
         nil

--- a/spec/determinator/control_spec.rb
+++ b/spec/determinator/control_spec.rb
@@ -17,6 +17,7 @@ describe Determinator::Control do
   let(:rollout) { 65_536 }
   # For the default identifier and id this is the lowest rollout percentage
   let(:not_quite_enough_rollout) { 2_024 }
+  let(:winning_variant) { 'enabled' }
 
   before do
     allow(retrieval).to receive(:retrieve).with(feature_name).and_return(feature)
@@ -224,6 +225,32 @@ describe Determinator::Control do
       let(:feature) { FactoryGirl.create(:feature, :full_rollout) }
 
       it { should eq false }
+    end
+
+    context 'when a winning variant is set' do
+      let(:winning_variant) { 'enabled' }
+
+      let(:feature) { FactoryGirl.create(:experiment,
+        name: feature_name,
+        identifier: feature_identifier,
+        bucket_type: bucket_type,
+        overrides: overrides,
+        rollout: rollout,
+        constraints: feature_constraints,
+        winning_variant: winning_variant
+      ) }
+
+      subject(:method_call) { instance.which_variant(
+        feature_name,
+        id: id,
+        guid: guid,
+        constraints: actor_constraints
+      ) }
+
+      it 'is the winning variant' do
+        expect(subject).to eq(winning_variant)
+      end
+
     end
   end
 end


### PR DESCRIPTION
This PR
* adds a new instance variable `:winning_variant` for feature model
* returns the winning variant as a winner if its set