### PR TITLE
FLO-12: Hash Overrides and Constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ Breaking changes:
 Features:
 - Remove siphon drain step, determinator now requires just a drain that expires caches. Also Removes the caching step for ID lookup (#24)
 - Added Determinator RSpec helper (#26)
-
+- Allows Determinator to accept both legacy and new style contraint and override specifications, for upcoming Florence API migration (#25)

--- a/spec/determinator/retrieve/routemaster_spec.rb
+++ b/spec/determinator/retrieve/routemaster_spec.rb
@@ -3,9 +3,9 @@ require "spec_helper"
 describe Determinator::Retrieve::Routemaster do
   let(:instance) { described_class.new(discovery_url: discovery_url) }
   let(:discovery_url) { 'https://florence' }
-  let(:routemaster) { double }
-  let(:routemaster_app) { double }
-  let(:cache_redis) { double }
+  let(:routemaster) { double('routemaster') }
+  let(:routemaster_app) { double('routemaster app') }
+  let(:cache_redis) { double('redis') }
 
   before do
     allow_any_instance_of(::Routemaster::APIClient).to receive(:discover).and_return(routemaster)
@@ -19,89 +19,129 @@ describe Determinator::Retrieve::Routemaster do
     subject(:method_call) { instance.retrieve(feature_id) }
     let(:feature_name) { 'My Feature' }
     let(:feature_id) { feature_name.parameterize }
-    let(:override) { double(user_id: rand(100), variant: 'blue') }
+    let(:override) { { user_id: rand(100), variant: 'blue'} }
 
-    let(:routemaster_scope) { double }
-    let(:hateoas_response) { Hashie::Mash.new(
-      body: {
-        id: feature_id,
-        name: feature_name,
-        identifier: 'a',
-        bucket_type: 'id',
-        active: true,
-        target_groups: [
-          {
-            rollout: 32_768,
-            constraints: []
-          },{
-            rollout: 1_000,
-            constraints: [{
-              type: 'value'
-            }]
-          }
-        ],
-        variants: {
-          red: 1,
-          blue: 1
-        },
-        overrides: [override]
-      }
-    ) }
+    let(:routemaster_scope) { double('routemaster scope') }
 
-    before do
-      # Mocking routemaster
-      allow(routemaster).to receive(:feature).and_return(routemaster_scope)
-    end
-
-    context 'when the request feature exists in Florence' do
+    shared_examples 'correctly parses Feature objects' do
       before do
-        expect(routemaster_scope).to receive(:show).with(feature_id).and_return(hateoas_response)
+        # Mocking routemaster
+        allow(routemaster).to receive(:feature).and_return(routemaster_scope)
       end
 
-      it 'should collect the raw feature details from routemaster' do
-        # expectation in before block
-        method_call
-      end
+      context 'when the request feature exists in Florence' do
+        before do
+          expect(routemaster_scope).to receive(:show).with(feature_id).and_return(hateoas_response)
+        end
 
-      it { should be_kind_of(Determinator::Feature) }
+        it 'should collect the raw feature details from routemaster' do
+          # expectation in before block
+          method_call
+        end
 
-      its(:name) { should eq feature_name }
-      its(:identifier) { should eq 'a' }
-      its(:bucket_type) { should eq :id }
-      its(:variants) { should eq('red' => 1, 'blue' => 1) }
-      its(:overrides) { should eq(override.user_id.to_s => override.variant)}
-      its(:target_groups) { should eq [
-        Determinator::TargetGroup.new(
-          rollout: 32_768,
-          constraints: {}
-        ),
-        Determinator::TargetGroup.new(
-          rollout: 1_000,
-          constraints: {
-            'type' => 'value'
-          }
-        )
-      ] }
+        it { should be_kind_of(Determinator::Feature) }
 
-      context "when given a cache retriver" do
-        let(:instance) { described_class.new(discovery_url: discovery_url, retrieval_cache: cache_double) }
-        let(:cache_double){ double }
+        its(:name) { should eq feature_name }
+        its(:identifier) { should eq 'a' }
+        its(:bucket_type) { should eq :id }
+        its(:variants) { should eq('red' => 1, 'blue' => 1) }
+        its(:overrides) { should eq(override[:user_id].to_s => override[:variant])}
+        its(:target_groups) { should eq [
+          Determinator::TargetGroup.new(
+            rollout: 32_768,
+            constraints: {}
+          ),
+          Determinator::TargetGroup.new(
+            rollout: 1_000,
+            constraints: {
+              'country' => 'uk'
+            }
+          )
+        ] }
 
-        it "should call fetch, returning a routemaster object " do
-          expect(cache_double).to receive(:fetch) { |&block| block.call }
-          expect(subject).to be_kind_of(Determinator::Feature)
+        context "when given a cache retriver" do
+          let(:instance) { described_class.new(discovery_url: discovery_url, retrieval_cache: cache_double) }
+          let(:cache_double){ double('cache_double') }
+
+          it "should call fetch, returning a routemaster object " do
+            expect(cache_double).to receive(:fetch) { |&block| block.call }
+            expect(subject).to be_kind_of(Determinator::Feature)
+          end
         end
       end
+
+      context "when the requested feature isn't present in Florence" do
+        before do
+          allow(routemaster_scope).to receive(:show).with(feature_id).and_raise(
+            ::Routemaster::Errors::ResourceNotFound.new({})
+          )
+        end
+
+        it { should be_nil }
+      end
     end
 
-    context "when the requested feature isn't present in Florence" do
-      before do
-        allow(routemaster_scope).to receive(:show).with(feature_id).and_raise(
-          ::Routemaster::Errors::ResourceNotFound.new({})
-        )
-      end
+    context 'with a legacy API service' do
+      let(:hateoas_response) { Hashie::Mash.new(
+        body: {
+          id: feature_id,
+          name: feature_name,
+          identifier: 'a',
+          bucket_type: 'id',
+          active: true,
+          target_groups: [
+            {
+              rollout: 32_768,
+              constraints: []
+            },{
+              rollout: 1_000,
+              constraints: [{
+                scope: 'country',
+                identifier: 'uk'
+              }]
+            }
+          ],
+          variants: {
+            red: 1,
+            blue: 1
+          },
+          overrides: [override]
+        }
+      ) }
 
-      it { should be_nil }
+      include_examples 'correctly parses Feature objects'
+    end
+
+    context 'with a modern API service' do
+      let(:hateoas_response) { Hashie::Mash.new(
+        body: {
+          id: feature_id,
+          name: feature_name,
+          identifier: 'a',
+          bucket_type: 'id',
+          active: true,
+          target_groups: [
+            {
+              rollout: 32_768,
+              constraints: {}
+            },{
+              rollout: 1_000,
+              constraints: {
+                country: 'uk'
+              }
+            }
+          ],
+          variants: {
+            red: 1,
+            blue: 1
+          },
+          overrides: {
+            override[:user_id] => override[:variant]
+          }
+        }
+      ) }
+
+      include_examples 'correctly parses Feature objects'
     end
   end
 end


### PR DESCRIPTION
Allows Determinator to accept both old-style constraints and overrides (arrays of keys) and new style (hashes)

===

Jira story [#FLO-12](https://deliveroo.atlassian.net/browse/FLO-12) in project *Florence*:

> ## What
> 
> Determinator currently cannot understand Hash constraints or overrides. We need to move actor tracking to emit these at some point (FLO-3, FLO-1), but Determinator must be able to cope with these beforehand.