### PR TITLE
FLO-14: Adds RSpec helper library for determination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # HEAD
 
 Features:
-Remove siphon drain step, determinator now requires just a drain that expires caches. Also Removes the caching step for ID lookup (#24)
+- Remove siphon drain step, determinator now requires just a drain that expires caches. Also Removes the caching step for ID lookup (#24)
+- Added Determinator RSpec helper (#26)

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -36,11 +36,22 @@ module RSpec
         constraints[:id] = id if id
         constraints[:guid] = guid if guid
 
-        return false unless @mocked_results[name.to_s].has_key?(constraints)
-        @mocked_results[name.to_s][constraints]
+        outcome_for_feature_given_properties(name.to_s, constraints)
       end
       alias_method :feature_flag_on?, :fake_determinate
       alias_method :which_variant, :fake_determinate
+
+      private
+
+      def outcome_for_feature_given_properties(feature_name, requirements)
+        req_array = requirements.to_a
+
+        _, forced = @mocked_results[feature_name].find do |given, outcome|
+          (given.to_a - req_array).empty?
+        end
+
+        forced || false
+      end
     end
   end
 end

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -1,0 +1,50 @@
+require 'determinator'
+
+module RSpec
+  module Determinator
+    def self.included(by)
+      by.extend(DSL)
+
+      by.let(:fake_determinator) { FakeControl.new }
+      by.before do
+        allow(::Determinator::Control).to receive(:new).and_return(fake_determinator)
+      end
+    end
+
+    module DSL
+      def forced_determination(name, result, only_for: {})
+        before do
+          fake_determinator.mock_result(
+            name,
+            result,
+            only_for: only_for
+          )
+        end
+      end
+    end
+
+    class FakeControl
+      def initialize
+        @mocked_results = Hash.new { |h, k| h[k] = {} }
+      end
+
+      def mock_result(name, result, only_for: {})
+        @mocked_results[name.to_s][only_for] = result
+      end
+
+      def fake_determinate(name, id: nil, guid: nil, constraints: {})
+        constraints[:id] = id if id
+        constraints[:guid] = guid if guid
+
+        return false unless @mocked_results[name.to_s].has_key?(constraints)
+        @mocked_results[name.to_s][constraints]
+      end
+      alias_method :feature_flag_on?, :fake_determinate
+      alias_method :which_variant, :fake_determinate
+    end
+  end
+end
+
+RSpec.configure do |conf|
+  conf.include RSpec::Determinator, :determinator_support
+end

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -1,0 +1,34 @@
+require 'rspec/determinator'
+
+describe RSpec::Determinator, :determinator_support do
+  subject(:determinator) { Determinator.configure(retrieval: nil) }
+
+  describe 'the determination for the experiment' do
+    subject(:determination) { determinator.which_variant(:my_experiment, constraints: constraints) }
+    let(:constraints) { {} }
+
+    context 'when not forcing a determination' do
+      it { should eq false }
+    end
+
+    context 'when forcing a determination' do
+      forced_determination(:my_experiment, 'outcome')
+
+      it { should eq 'outcome' }
+    end
+
+    context 'when forcing a determination for actors with specific properties that match' do
+      forced_determination(:my_experiment, 'outcome', only_for: { property: 'correct' })
+      let(:constraints) { { property: 'correct' } }
+
+      it { should eq 'outcome' }
+    end
+
+    context 'when forcing a determination for actors with specific properties that do not match' do
+      forced_determination(:my_experiment, 'outcome', only_for: { property: 'incorrect' })
+      let(:constraints) { { property: 'correct' } }
+
+      it { should eq false }
+    end
+  end
+end

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -30,5 +30,21 @@ describe RSpec::Determinator, :determinator_support do
 
       it { should eq false }
     end
+
+    context 'when forcing a determination for actors with specific properties that match enough' do
+      forced_determination(:my_experiment, 'outcome', only_for: { property: 'correct' })
+      let(:constraints) { { property: 'correct', extra: 'also present' } }
+
+      it { should eq 'outcome' }  
+    end
+
+    context 'when forcing more than one matching determination' do
+      forced_determination(:my_experiment, 'first outcome', only_for: { property: 'correct' })
+      forced_determination(:my_experiment, 'second outcome', only_for: { extra: 'also present' })
+
+      let(:constraints) { { property: 'correct', extra: 'also present' } }
+
+      it { should eq 'first outcome' }  
+    end
   end
 end


### PR DESCRIPTION
Having accidentally merged the work (!) this PR fleshes out the specs for the RSpec helpers for determination.

```ruby
require 'rspec/determinator'

RSpec.describe YourClass, :determinator_support do

  context "when the actor is in variant_a" do
    forced_determination(:experiment_name, 'variant_a')

    it "should respond in a way that is defined by variant_a"
  end

   context "when the actor is not in the experiment" do
    forced_determination(:experiment_name, false)

    it "should respond in a way that is defined by being out of the experiment"
  end

  context "when the actor is not from France" do
    forced_determination(:experiment_name, 'variant_b', only_for: { country: 'fr' })

    it "should respond in a way that is defined by being out of the experiment"
  end
end
```