### PR TITLE
FLO-21: Fixes typo from PR #27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.9.1 (2017-09-14)
+
+Bug fix:
+- Fixes an issue where PR #27 missed one instance of syntactic sugar where `constraints` needed to be switched to `properties`. (#30)
+
 # v0.9.0 (2017-09-14)
 
 This version of Determiantor introduces some breaking changes as we move to getting the Florence ecosystem more ready for a wider audience. A 1.0.0 release will follow shortly with few additional features, but with significantly more documentation.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ when 'velociraptors'
 end
 ```
 
-Feature flags and Experiments can be configured to have string based constraints. When the strings required for the experiment do not match, the user will _never_ see the flag or the experiment, when they match, then the rollout specified by the feature will be applied.
+Feature flags and Experiments can be configured to have string based constraints. When the experiment's _constraints_ do not match the given actor's _properties_, the flag or experiment will always be off. When they match the rollout specified by the feature will be applied.
 
 Constraints must be strings, what matches and doesn't is configurable after-the-fact within Florence.
 
@@ -33,7 +33,7 @@ Constraints must be strings, what matches and doesn't is configurable after-the-
 # Constraints
 variant = determinator.which_variant(
   :my_experiment_name,
-  constraints: {
+  properties: {
     country_of_first_order: current_user.orders.first.country.tld,
   }
 )

--- a/lib/determinator/actor_control.rb
+++ b/lib/determinator/actor_control.rb
@@ -3,7 +3,7 @@ module Determinator
   # Useful for contexts where the actor remains constant (eg. inside
   # the request cycle in a webapp)
   class ActorControl
-    attr_reader :id, :guid, :default_constraints
+    attr_reader :id, :guid, :default_properties
 
     # @see Determinator::Control#for_actor
     def initialize(controller, id: nil, guid: nil, default_properties: {})


### PR DESCRIPTION
Fixes an issue where PR #27 missed one instance of syntactic sugar where `constraints` needed to be switched to `properties`.