### PR TITLE
FLO-26: Make sure constraints and properties match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# HEAD
+
+Bug fix:
+- Ensure constraints and properties are string-keyed so that they match regardless of which are used (#33)
+
 # v0.10.0 (2017-09-15)
 
 Feature:

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -86,9 +86,14 @@ module Determinator
     end
 
     def choose_target_group(feature, properties)
+      # Keys must be strings
+      normalised_properties = properties.each_with_object({}) do |(k, v), h|
+        h[k.to_s] = v
+      end
+
       feature.target_groups.select { |tg|
         tg.constraints.reduce(true) do |fit, (scope, *required)|
-          present = [*properties[scope]]
+          present = [*normalised_properties[scope.to_s]]
           fit && (required.flatten & present.flatten).any?
         end
       # Must choose target group deterministically, if more than one match

--- a/lib/determinator/retrieve/routemaster.rb
+++ b/lib/determinator/retrieve/routemaster.rb
@@ -47,10 +47,6 @@ module Determinator
         @routemaster_app ||= ::Routemaster::Drain::Caching.new
       end
 
-      def self.index_cache_key(feature_name)
-        "determinator_index:#{feature_name}"
-      end
-
       def self.lookup_cache_key(feature_name)
         "determinator_cache:#{feature_name}"
       end

--- a/spec/determinator/control_spec.rb
+++ b/spec/determinator/control_spec.rb
@@ -57,6 +57,12 @@ describe Determinator::Control do
       it { should eq match_value }
     end
 
+    context "when the actor properties have string keys, but the constraints have symbol keys" do
+      let(:actor_properties) { { 'a' => '1' } }
+
+      it { should eq match_value }
+    end
+
     context "when the actor properties don't match" do
       let(:actor_properties) { { a: '2' } }
 
@@ -160,6 +166,12 @@ describe Determinator::Control do
 
     context "when the feature has one target group with one constraint" do
       let(:feature_constraints) { { a: '1' } }
+
+      include_examples 'for various actor properties', responses[:name]
+    end
+
+    context "when the feature has one target group with one constraint with a string key" do
+      let(:feature_constraints) { { 'a' => '1' } }
 
       include_examples 'for various actor properties', responses[:name]
     end


### PR DESCRIPTION
Make sure all constraints and properties are string-keyed so they match when they are the same.

FLO-26