### PR TITLE
👨‍🔧 More usable RSpec::Determinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Bug fix:
 - Ensure constraints and properties are string-keyed so that they match regardless of which are used (#33)
+- Be more permissive with the situations where `Rspec::Determinator` can be used (#34)
 
 # v0.10.0 (2017-09-15)
 

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -7,7 +7,7 @@ module RSpec
 
       by.let(:fake_determinator) { FakeControl.new }
       by.before do
-        allow(::Determinator::Control).to receive(:new).and_return(fake_determinator)
+        allow(::Determinator).to receive(:instance).and_return(fake_determinator)
       end
     end
 

--- a/spec/determinator/retrieve/routemaster_spec.rb
+++ b/spec/determinator/retrieve/routemaster_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Determinator::Retrieve::Routemaster do
   let(:instance) { described_class.new(discovery_url: discovery_url) }
-  let(:discovery_url) { 'https://florence' }
+  let(:discovery_url) { 'https://flo.dev' }
   let(:routemaster) { double('routemaster') }
   let(:routemaster_app) { double('routemaster app') }
   let(:cache_redis) { double('redis') }

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -1,7 +1,11 @@
 require 'rspec/determinator'
 
+# Determinator config is always done outside tests, this
+# emulates that.
+Determinator.configure(retrieval: nil)
+
 describe RSpec::Determinator, :determinator_support do
-  subject(:determinator) { Determinator.configure(retrieval: nil) }
+  subject(:determinator) { Determinator.instance }
 
   describe 'the determination for the experiment' do
     subject(:determination) { determinator.which_variant(:my_experiment, properties: properties) }


### PR DESCRIPTION
`Determinator.configure` is usually called in such a way that it is executed before specs are loaded, meaning that `RSpec::Determinator` is useless. This change stubs `Determinator.instance` instead, which brings back the required functionality.

FLO-28