### PR TITLE
FLO-37: Swallow not-found routemaster errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bug fix:
 - Ensure constraints and properties are string-keyed so that they match regardless of which are used (#33)
 - Be more permissive with the situations where `Rspec::Determinator` can be used (#34)
+- Swallow not found errors from routemaster so determinator isn't too shouty, allow them to be tracked. (#35)
 
 # v0.10.0 (2017-09-15)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Determinator.configure(
     discovery_url: 'https://flo.dev/'
     retrieval_cache: ActiveSupport::Cache::MemoryStore.new(expires_in: 1.minute)
   ),
-  errors: -> error { NewRelic::Agent.notice_error(error) }
+  errors: -> error { NewRelic::Agent.notice_error(error) },
+  missing_features: -> feature_name { STATSD.increment 'determinator.missing_feature', tags: ["feature:#{name}"] }
 )
 ```
 

--- a/lib/determinator.rb
+++ b/lib/determinator.rb
@@ -7,9 +7,11 @@ require 'determinator/retrieve/null_retriever'
 
 module Determinator
   # @param :retrieval [Determinator::Retrieve::Routemaster] A retrieval instance for Features
-  # @param :errors [Proc, nil] a proc, accepting an error, which will be called with any errors which occur while determinating
-  def self.configure(retrieval:, errors: nil)
+  # @param :errors [#call, nil] a proc, accepting an error, which will be called with any errors which occur while determinating
+  # @param :missing_feature [#call, nil] a proc, accepting a feature name, which will be called any time a feature is requested but isn't available
+  def self.configure(retrieval:, errors: nil, missing_feature: nil)
     @error_logger = errors if errors.respond_to?(:call)
+    @missing_feature_logger = missing_feature if missing_feature.respond_to?(:call)
     @instance = Control.new(retrieval: retrieval)
   end
 
@@ -22,5 +24,11 @@ module Determinator
     return unless @error_logger
 
     @error_logger.call(error)
+  end
+
+  def self.missing_feature(name)
+    return unless @missing_feature_logger
+
+    @missing_feature_logger.call(name)
   end
 end

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -57,7 +57,10 @@ module Determinator
 
     def determinate(name, id:, guid:, properties:)
       feature = retrieval.retrieve(name)
-      return false unless feature
+      if feature.nil?
+        Determinator.missing_feature(name)
+        return false
+      end
 
       # Calling method can place constraints on the feature, eg. experiment only
       return false if block_given? && !yield(feature)

--- a/lib/determinator/retrieve/routemaster.rb
+++ b/lib/determinator/retrieve/routemaster.rb
@@ -31,6 +31,9 @@ module Determinator
         cached_feature_lookup(feature_id) do
           @actor_service.feature.show(feature_id)
         end
+      rescue ::Routemaster::Errors::ResourceNotFound
+        # Don't be noisy
+        nil
       rescue => e
         Determinator.notice_error(e)
         nil

--- a/spec/determinator/control_spec.rb
+++ b/spec/determinator/control_spec.rb
@@ -195,6 +195,18 @@ describe Determinator::Control do
     it { should eq(false) }
   end
 
+  shared_examples "feature doesn't exist" do
+    context 'when the feature is missing' do
+      # This mocks that the retrieval class doesn't have the feature
+      let(:feature) { nil }
+
+      it 'should call the missing feature proc' do
+        expect(Determinator).to receive(:missing_feature).with(feature_name)
+        method_call
+      end
+    end
+  end
+
   # Tests for features
   describe '#feature_flag_on?' do
     subject(:method_call) { instance.feature_flag_on?(
@@ -224,6 +236,8 @@ describe Determinator::Control do
     context 'when the feature is inactive' do
       it_behaves_like 'feature is inactive'
     end
+
+    include_examples "feature doesn't exist"
   end
 
   # Tests for experiments
@@ -281,5 +295,7 @@ describe Determinator::Control do
         expect(subject).to eq(winning_variant)
       end
     end
+
+    include_examples "feature doesn't exist"
   end
 end


### PR DESCRIPTION
- Stops routemaster from shouting when there is a legitimate 404
- Allows implementers to track missing features in whatever way they like.

===

Jira story [#FLO-37](https://deliveroo.atlassian.net/browse/FLO-37) in project *Florence*:

> ## What
> 
> When a feature doesn't exist we shouldn't be raising an exception (as we can't always control what features are requested - eg. the `/config` endpoint).
> 
> We _should_ however track when a feature is missing.