### PR TITLE
Support example-scoped variables in RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# HEAD
+
+Feature:
+- Allows the use of example-scoped variables for outcomes and constraints in `RSpec::Determinator`'s mocks. (#36)
+
 # v0.11.0 (2017-10-13)
 
 Bug fix:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ variant = determinator.which_variant(
 )
 ```
 
+Writing tests? Check out the [Local development](docs/local_development.md) docs to see examples of `RSpec::Determinator` to help you mock your Feature Flags and Experiments.
+
 ## Installation
 
 Determinator requires your application to be subscribed to the a `features` topic via Routemaster.

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -15,14 +15,18 @@ RSpec.describe YourClass, :determinator_support do
     # This allows testing of the experiment being in a specific variant
     forced_determination(:experiment_name, 'variant_a')
 
-    it "should respond in a way that is defined by variant_a"
+    it "should respond in a way that is defined by variant_a" do
+      # … etc
+    end
   end
 
   context "when the actor is not in the experiment" do
     # This allows testing of the experiment being off
     forced_determination(:experiment_name, false)
 
-    it "should respond in a way that is defined by being out of the experiment"
+    it "should respond in a way that is defined by being out of the experiment" do
+      # … etc
+    end
   end
 
   context "when the actor is not from France" do
@@ -30,7 +34,18 @@ RSpec.describe YourClass, :determinator_support do
     # This allows testing of target group constraint functionality
     forced_determination(:experiment_name, 'variant_b', only_for: { country: 'fr' })
 
-    it "should respond in a way that is defined by being out of the experiment"
+    it "should respond in a way that is defined by being out of the experiment" do
+      # … etc
+    end
+  end
+
+  context "when the constraints are defined dynamically" do
+    forced_determination(:experiment_name, 'variant_b', only_for: constraints)
+    let(:constraints) { { employee: true } }
+
+    it "should respond in a way that shows employees the experiment" do
+      # … etc
+    end
   end
 
   context "when the actor has a specified id" do
@@ -38,10 +53,13 @@ RSpec.describe YourClass, :determinator_support do
     # This allows testing of override functionality
     forced_determination(:experiment_name, 'variant_b', only_for: { id: '123' })
 
-    it "should respond in a way that is defined by variant_b"
-  end
+    it "should respond in a way that is defined by variant_b" do
+      # … etc
+    end
 end
 ```
+
+Note that you can use Symbols for either the constraint declaration (`only_for`) or the outcome declaration and that variable or method will be called and the result used for that value. This is particularly helpful for examples which use the `let` scope declarations for cleaner tests.
 
 ## Fake Florence for local execution
 

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -12,11 +12,23 @@ module RSpec
     end
 
     module DSL
-      def forced_determination(name, result, only_for: {})
+      # Ensure that for the duration of the example all determinations made for the given experiment or feature flag
+      # will have the given outcome (but only if the constraints specified are met exactly).
+      #
+      # If `outcome` or `only_for` are Symbols then the example-scoped variable of that name will be referenced (ie. those
+      # variables created by `let` declarations)
+      #
+      # @params name [#to_s] The name of the Feature Flag or Experiment to mock
+      # @params outcome [Boolean,String,Symbol] The outcome which should be supplied. Will look up an example variable if a Symbol is given.
+      # @params :only_for [Hash,Symbol] The constraints that must be matched exactly in order for the determination to be applied.
+      def forced_determination(name, outcome, only_for: {})
         before do
+          outcome = send(outcome) if outcome.is_a?(Symbol)
+          only_for = send(only_for) if only_for.is_a?(Symbol)
+
           fake_determinator.mock_result(
             name,
-            result,
+            outcome,
             only_for: only_for
           )
         end

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -21,8 +21,22 @@ describe RSpec::Determinator, :determinator_support do
       it { should eq 'outcome' }
     end
 
+    context 'when forcing a determination with an example-scoped variable for the outcome' do
+      forced_determination(:my_experiment, :outcome)
+      let(:outcome) { 'some_outcome' }
+
+      it { should eq 'some_outcome' }
+    end
+
     context 'when forcing a determination for actors with specific properties that match' do
       forced_determination(:my_experiment, 'outcome', only_for: { property: 'correct' })
+      let(:properties) { { property: 'correct' } }
+
+      it { should eq 'outcome' }
+    end
+
+    context 'when forcing a determination for actors with specific properties that match when using an example-scoped variable for constraints' do
+      forced_determination(:my_experiment, 'outcome', only_for: :properties)
       let(:properties) { { property: 'correct' } }
 
       it { should eq 'outcome' }


### PR DESCRIPTION
Allows the use of example-scoped variables for outcomes and constraints in `RSpec::Determinator`'s mocks.