### PR TITLE
Add helper method for feature lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# HEAD
+
+Feature:
+- Adds the `Determinator.feature_details` method, which allows lookup of feature details as are currently available to Determinator. Whatever is returned here is what Determinator is acting upon. (#38)
+
 # v0.11.1 (2017-10-27)
 
 Feature:

--- a/lib/determinator.rb
+++ b/lib/determinator.rb
@@ -15,9 +15,18 @@ module Determinator
     @instance = Control.new(retrieval: retrieval)
   end
 
+  # @return [Determinator::Control] The currently active instance of determinator.
+  # @raises [RuntimeError] If no Determinator instance is set up (with `.configure`)
   def self.instance
     raise "No singleton Determinator instance defined" unless @instance
     @instance
+  end
+
+  # Returns the feature with the given name as Determinator uses it. This is useful for
+  # debugging issues with the retrieval mechanism which delivers features to Determinator.
+  # @returns [Determinator::Feature,nil] The feature details Determinator would use for a determination right now.
+  def self.feature_details(name)
+    instance.retrieval.retrieve(name)
   end
 
   def self.notice_error(error)

--- a/lib/determinator/retrieve/routemaster.rb
+++ b/lib/determinator/retrieve/routemaster.rb
@@ -27,9 +27,11 @@ module Determinator
 
       end
 
-      def retrieve(feature_id)
-        cached_feature_lookup(feature_id) do
-          @actor_service.feature.show(feature_id)
+      # Retrieves and processes the feature that goes by the given name on this retrieval mechanism.
+      # @return [Determinator::Feature,nil] The details of the specified feature
+      def retrieve(name)
+        cached_feature_lookup(name) do
+          @actor_service.feature.show(name)
         end
       rescue ::Routemaster::Errors::ResourceNotFound
         # Don't be noisy


### PR DESCRIPTION
Adds the `Determinator.feature_details` method, which allows lookup of feature details as are currently available to Determinator. Whatever is returned here is what Determinator is acting upon.

Adds a little extra YARDoc for the good times.

```irb
> Determinator.feature_details(:my_exciting_feature)
=> #<Determinator::Feature:0x007fdc7a3f9f48
   @active=true,
   @bucket_type=:guid,
   @identifier="my_exciting_feature",
   @name="my_exciting_feature",
   @overrides={},
   @target_groups=[<100.0% of those matching: #<Hashie::Mash>>],
   @variants={},
   @winning_variant=nil>
```