### PR TITLE
👨‍⚕️ Fix vulnerable dependency in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Feature:
 - Adds the `Determinator.feature_details` method, which allows lookup of feature details as are currently available to Determinator. Whatever is returned here is what Determinator is acting upon. (#38)
 
+Bug Fix:
+- Upgrades a dependency of the example rails app which has a known vulnerability. (#39)
+
 # v0.11.1 (2017-10-27)
 
 Feature:

--- a/examples/determinator-rails/Gemfile.lock
+++ b/examples/determinator-rails/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../..
   specs:
-    determinator (0.1.0)
-      routemaster-drain (~> 2.5)
+    determinator (0.11.1)
+      routemaster-drain (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -44,11 +44,14 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (7.1.4)
     builder (3.2.3)
     byebug (9.0.6)
+    circuitbox (1.1.1)
+      activesupport
+      moneta
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     dotenv (2.2.0)
@@ -56,16 +59,16 @@ GEM
       dotenv (= 2.2.0)
       railties (>= 3.2, < 5.1)
     erubis (2.7.0)
-    ethon (0.10.1)
+    ethon (0.11.0)
       ffi (>= 1.3.0)
-    faraday (0.11.0)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.11.0.1)
+    faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.18)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    hashie (3.5.5)
+    hashie (3.5.7)
     i18n (0.8.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -75,13 +78,14 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
+    moneta (1.0.0)
     multipart-post (2.0.0)
     nio4r (2.0.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
-    public_suffix (2.0.5)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    public_suffix (3.0.1)
     puma (3.8.2)
     rack (2.0.1)
     rack-protection (1.5.3)
@@ -113,10 +117,11 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     redis (3.3.3)
-    redis-namespace (1.5.3)
-      redis (~> 3.0, >= 3.0.4)
-    routemaster-drain (2.5.0)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
+    routemaster-drain (3.4.0)
       addressable
+      circuitbox
       concurrent-ruby
       faraday (>= 0.9.0)
       faraday_middleware
@@ -139,7 +144,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    typhoeus (1.1.2)
+    typhoeus (1.3.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -160,4 +165,4 @@ DEPENDENCIES
   sidekiq
 
 BUNDLED WITH
-   1.13.6
+   1.16.0


### PR DESCRIPTION
The example rails app depended on nokogiri 1.7.1, which has a known vulnerability.