### PR TITLE
👨‍🎨 Allow for_actor on fake determinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# HEAD
+
+Bug Fix:
+- Allow `.for_actor` calls when using `RSpec::Determinator` to test code that uses determinator. (#44)
+
 # v0.12.0 (2018-01-23)
 
 Feature:

--- a/README.md
+++ b/README.md
@@ -147,32 +147,33 @@ The drain must expire the routemaster cache on receipt of events, making use of 
 
 * Include the  `spec_helper.rb`.
 
-
-```
+```ruby
 require 'rspec/determinator'
 
 Determinator.configure(retrieval: nil)
 ```
 
-* Tag your rspec test with `:determinator_support`, so `forced_determination` helper method will be available.
+* Tag your rspec test with `:determinator_support`, so the `forced_determination` helper method will be available.
 
-
-```
-
+```ruby
 RSpec.describe "something", :determinator_support do
 
   context "something" do
     forced_determination(:my_feature_flag, true)
     forced_determination(:my_experiment, "variant_a")
+    forced_determination(:my_lazyexperiment, :some_lazy_variable)
+    let(:some_lazy_variable) { 'variant_b' }
 
     it "uses forced_determination" do
       expect(Determinator.instance.feature_flag_on?(:my_feature_flag)).to eq(true)
       expect(Determinator.instance.which_variant(:my_experiment)).to eq("variant_a")
+      expect(Determinator.instance.which_variant(:my_lazy_experiment)).to eq("variant_b")
     end
   end
 end
-
 ```
+
+* Check out [the specs for `RSpec::Determinator`](spec/rspec/determinator_spec.rb) to find out what you can do!
 
 ### Retrieval Cache
 

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -40,6 +40,10 @@ module RSpec
         @mocked_results = Hash.new { |h, k| h[k] = {} }
       end
 
+      def for_actor(**args)
+        ::Determinator::ActorControl.new(self, **args)
+      end
+
       def mock_result(name, result, only_for: {})
         @mocked_results[name.to_s][only_for] = result
       end

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -64,5 +64,19 @@ describe RSpec::Determinator, :determinator_support do
 
       it { should eq 'first outcome' }
     end
+
+    context 'when using an ActorControl proxy' do
+      let(:determinator) { Determinator.instance.for_actor(id: 123) }
+
+      context 'when not forcing a determination' do
+        it { should eq false }
+      end
+
+      context 'when forcing a determination' do
+        forced_determination(:my_experiment, 'outcome')
+
+        it { should eq 'outcome' }
+      end
+    end
   end
 end


### PR DESCRIPTION
The mocking classes didn't allow .for_actor, but now they do.