### PR TITLE
👀 Determination callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Feature:
 - Changes tests to use the [Determinator standard tests](https://github.com/deliveroo/determinator-standard-tests) (#41)
 - Supports the use of the 'single' bucket type for features, which allows (only) feature flags to be on or off, without any `id` or `guid` specified. (#41)
+- Adds Determintion callbacks: trigger a block when a determination is made, allowing for experiment tracking. (#45)
 
 # v0.12.1 (2018-02-01)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Determinator.on_error(NewRelic::Agent.method(:notice_error))
 Determinator.on_missing_feature do |feature_name|
   STATSD.increment 'determinator.missing_feature', tags: ["feature:#{name}"]
 end
+
+Determinator.on_determination do |id, guid, feature, determination|
+  if feature.experiment? && determination !== false
+    YourTrackingSolution.record_variant_viewing(
+      user_id: id,
+      experiment_name: feature.name,
+      variant: determination
+    )
+  end
+end
 ```
 
 This configures the `Determinator.instance` with:

--- a/spec/determinator_spec.rb
+++ b/spec/determinator_spec.rb
@@ -6,4 +6,38 @@ describe Determinator do
 
     it { should match(%r{\A\d+\.\d+\.\d+\z}) }
   end
+
+  describe '::on_error and ::notice_error' do
+    it 'sets the error logger callback' do
+      error = StandardError.new "Some error"
+      error_notified = false
+
+      described_class.on_error do |err|
+        error_notified = true if err == error
+      end
+
+      described_class.notice_error(error)
+      expect(error_notified).to be true
+    end
+  end
+
+  describe '::on_determination and ::notice_determination' do
+    it 'sets the determination callback' do
+      id = 'id'
+      guid = 'guid'
+      feature = FactoryGirl.create(:feature)
+      determination = 'variant'
+
+      determiantion_notified = false
+
+      described_class.on_determination do |i, g, f, d|
+        if i == id && g = guid && f == feature && d == determination
+          determiantion_notified = true
+        end
+      end
+
+      described_class.notice_determination(id, guid, feature, determination)
+      expect(determiantion_notified).to be true
+    end
+  end
 end


### PR DESCRIPTION
Gives a framework for running a callback when a determination is made. This allows for simple and centralised tracking of experiments:

```ruby
Determinator.on_determination do |id, guid, feature, determination|
  if feature.experiment? && determination !== false
    YourTrackingSolution.record_variant_viewing(
      user_id: id,
      experiment_name: feature.name,
      variant: determination
    )
  end
end
```