### PR TITLE
💎 Improve forced determination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.1.0 (2018-02-07)
+
+⚠️ This release includes breaking changes to `RSpec::Determinator` ⚠️
+
+Breaking change:
+- If two `forced_determination`s are made within one rspec test case, it is now the _last_ one that takes precedence (not the first). (#47)
+
+Bug fix:
+- `forced_determination`s which are called with differently typed parameters (eg. integer vs. string, boolean vs. string) will now work in the same way that real determination will. (#47)
+
 # v1.0.0 (2018-02-05)
 
 ⚠️ This release includes breaking changes ⚠️

--- a/README.md
+++ b/README.md
@@ -179,10 +179,21 @@ RSpec.describe "something", :determinator_support do
     forced_determination(:my_lazyexperiment, :some_lazy_variable)
     let(:some_lazy_variable) { 'variant_b' }
 
+    forced_determination(:my_targeted_feature_flag, true, only_for: { employee: true })
+    forced_determination(:my_targeted_feature_flag, false, only_for: { id: 12345 })
+
     it "uses forced_determination" do
-      expect(Determinator.instance.feature_flag_on?(:my_feature_flag)).to eq(true)
-      expect(Determinator.instance.which_variant(:my_experiment)).to eq("variant_a")
-      expect(Determinator.instance.which_variant(:my_lazy_experiment)).to eq("variant_b")
+      determinator = Determinator.for_actor(id: 1)
+
+      expect(determinator.feature_flag_on?(:my_feature_flag)).to be true
+      expect(determinator.which_variant(:my_experiment)).to eq("variant_a")
+      expect(determinator.which_variant(:my_lazy_experiment)).to eq("variant_b")
+
+      expect(determinator.feature_flag_on?(:my_targeted_feature_flag, properties: { employee: false })).to be false
+      expect(determinator.feature_flag_on?(:my_targeted_feature_flag, properties: { employee: true })).to be true
+
+      # The last forced determination takes precedence
+      expect(Determinator.instance.feature_flag_on?(:my_targeted_feature_flag, id: 12345, properties: { employee: true })).to be false
     end
   end
 end

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -35,6 +35,20 @@ describe RSpec::Determinator, :determinator_support do
       it { should eq 'outcome' }
     end
 
+    context 'when forcing a determination for actors with specific properties that match when the forced determination needs to be normalized' do
+      forced_determination(:my_experiment, 'outcome', only_for: { 'property' => 'correct' })
+      let(:properties) { { property: 'correct' } }
+
+      it { should eq 'outcome' }
+    end
+
+    context 'when forcing a determination for actors with specific properties that match when the determination needs to be normalized' do
+      forced_determination(:my_experiment, 'outcome', only_for: { property: 'correct' })
+      let(:properties) { { 'property' => 'correct' } }
+
+      it { should eq 'outcome' }
+    end
+
     context 'when forcing a determination for actors with specific properties that match when using an example-scoped variable for constraints' do
       forced_determination(:my_experiment, 'outcome', only_for: :properties)
       let(:properties) { { property: 'correct' } }
@@ -62,7 +76,7 @@ describe RSpec::Determinator, :determinator_support do
 
       let(:properties) { { property: 'correct', extra: 'also present' } }
 
-      it { should eq 'first outcome' }
+      it { should eq 'second outcome' }
     end
 
     context 'when using an ActorControl proxy' do


### PR DESCRIPTION
FLO-42: Reverse the order of forced determination priority (least surprise)
FLO-41: Ensure properties & only_for specifications are normalised

===

Jira story [#FLO-41](https://deliveroo.atlassian.net/browse/FLO-41) in project *Florence*
Jira story [#FLO-42](https://deliveroo.atlassian.net/browse/FLO-42) in project *Florence*
