### PR TITLE
Copy for easier local dev setup

### DIFF
--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -88,3 +88,30 @@ determinator.which_variant(:my_experiment, id: 123)
 ```
 
 More information can be found on the [Fake Florence](https://github.com/deliveroo/fake_florence) project page.
+
+## File support for local
+
+Alternatively, Determinator can be configured to read from  a local file store.
+
+Add 'local_feature_flags' to your .gitignore file and the following to your determinator setup initializer.
+
+```ruby
+# /config/initializers/determinator.rb
+require 'determinator/retrieve/file'
+retrieval = if Rails.env.development?
+              Determinator::Retrieve::File.new(
+                root: Rails.root.join('local_feature_flags')
+              )
+            else
+              #Your regular production config
+            end
+
+Determinator.configure(retrieval: retrieval)
+```
+
+Then add a your feature definitions as a json file (without an extension) to the `local_feature_flags` folder.
+
+```ruby
+  # checks /local_feature_flags/deliveroo_does
+  Determinator.instance.feature_flag_on?('deliveroo_does', id: 5)
+```

--- a/lib/determinator/retrieve/file.rb
+++ b/lib/determinator/retrieve/file.rb
@@ -12,7 +12,7 @@ module Determinator
       end
 
       def retrieve(feature_id)
-        feature = @root.join(feature_id)
+        feature = @root.join(feature_id.to_s)
         return unless feature.exist?
         @serializer.load(feature.read)
       rescue => e


### PR DESCRIPTION
At the moment it looks like it's a bit tricky to get fake florence set up in orderweb for local testing.

The setup looks like this:

```
if App.context.roobus.enabled && App.context.actor_tracking.enabled
  retrieval = Determinator::Retrieve::Routemaster.new(
    discovery_url: App.context.drain_cache.hosts.actor_tracking
  )
else
  retrieval = Determinator::Retrieve::NullRetriever.new(discovery_url: '')
end
```

That means you have to be able to boot routemaster.

This PR makes a small change to the File reader and proposes an easier setup without any external dependencies.