### PR TITLE
Mid-rollout single buckets are random

### DIFF
--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -135,7 +135,7 @@ module Determinator
 
         raise ArgumentError, 'An ID or GUID must always be given for Fallback bucketed features'
       when :single
-        'all'
+        SecureRandom.hex(64)
       else
         Determinator.notice_error "Cannot process the '#{feature.bucket_type}' bucket type found in #{feature.name}"
       end


### PR DESCRIPTION
- Minimises user surprise by ensuring the 'use nothing' buckets result in randomness for 1-99% rollouts.
- Introduces non-deterministic tests and 99.999% probability (so the test can be black-box, but will be flakey roughly one in 100,000 executions)

FLO-49