### PR TITLE
Add HttpRetriever and modify the cache to cascade

### DIFF
--- a/lib/determinator.rb
+++ b/lib/determinator.rb
@@ -7,6 +7,7 @@ require 'determinator/serializers/json'
 
 module Determinator
   class << self
+    attr_reader :feature_cache, :retrieval
     # @param :retrieval [Determinator::Retrieve::Routemaster] A retrieval instance for Features
     # @param :errors [#call, nil] a proc, accepting an error, which will be called with any errors which occur while determinating
     # @param :missing_feature [#call, nil] a proc, accepting a feature name, which will be called any time a feature is requested but isn't available
@@ -15,6 +16,7 @@ module Determinator
       self.on_error(&errors) if errors
       self.on_missing_feature(&missing_feature) if missing_feature
       @feature_cache = feature_cache if feature_cache.respond_to?(:call)
+      @retrieval = retrieval
       @instance = Control.new(retrieval: retrieval)
     end
 
@@ -88,6 +90,10 @@ module Determinator
       return yield unless @feature_cache.respond_to?(:call)
 
       @feature_cache.call(name) { yield }
+    end
+
+    def invalidate_cache(name)
+      @feature_cache.expire(name)
     end
   end
 end

--- a/lib/determinator/cache/fetch_wrapper.rb
+++ b/lib/determinator/cache/fetch_wrapper.rb
@@ -1,19 +1,57 @@
 module Determinator
   module Cache
     class FetchWrapper
-      # @param cache [#fetch] An instance of a cache class which implements #fetch like ActiveSupport::Cache does
-      def initialize(cache)
-        @cache = cache
+      # @param *caches [ActiveSupport::Cache] If a list then the head of the the
+      # list should will be checked before the  tail. If the head is empty but
+      # the tail is not then the head will be filled with the value of the tail.
+      def initialize(*caches)
+        @caches = caches
       end
 
+      # Call walks through each cache, returning a value if the item exists in
+      # any cache, otherwise popularing each cache with the value of yield.
       def call(feature_name)
-        @cache.fetch(key(feature_name)) { yield }
+        value = read_and_upfill(feature_name)
+        # nil is an acceptable value in the case of a missing feature definition
+        return nil if value.nil?
+        return value if value != false
+
+        value_to_write = yield
+        @caches.each do |cache|
+          cache.write(key(feature_name), value_to_write)
+        end
+        return value_to_write
+      end
+
+      def expire(feature_name)
+        @caches.each{ |c| c.delete(key(feature_name)) }
       end
 
       private
 
       def key(feature_name)
         "determinator:feature_cache:#{feature_name}"
+      end
+
+      # Walks through the list of caches, returning the first stored value.
+      #
+      # If a value is found in a cache after the first then all caches earlier
+      # in that list will be backfilled.
+      #
+      # @param url [String] a feature name
+      # @return [false, nil, Feature] false when no value is found, otherwise
+      # the value stored in the cache (including nil)
+      def read_and_upfill(feature_name)
+        @caches.each.with_index do |cache, index|
+          if cache.exist?(key(feature_name))
+            value = cache.read(key(feature_name))
+            @caches[0...index].each do |cache|
+              cache.write(key(feature_name), value)
+            end
+            return value
+          end
+        end
+        return false
       end
     end
   end

--- a/lib/determinator/retrieve/http_retriever.rb
+++ b/lib/determinator/retrieve/http_retriever.rb
@@ -1,0 +1,35 @@
+require 'faraday'
+
+module Determinator
+  module Retrieve
+
+    class HttpRetriever
+      def initialize(connection:)
+        raise ArgumentError, "client must be a Faraday::Connection" unless connection.is_a?(Faraday::Connection)
+        @connection = connection
+      end
+
+      def retrieve(name)
+        begin
+          response = @connection.get("/features/#{name}")
+          return Determinator::Serializers::JSON.load(response.body) if response.status == 200
+        rescue => e
+          Determinator.notice_error(e)
+        end
+        nil
+      end
+
+      # Returns a feature name given a actor-tracking url. Used so we are able
+      # to expire a cache using a feature name given an event url.
+      #
+      # Not intended to be generic, and makes no guarantees about support for
+      # alternative url schemes.
+      #
+      # @param url [String] a actor tracking url
+      # @return [String, nil] a feature name or nil
+      def get_name(url)
+        (url.match('features\/(.*)\z') || [])[1]
+      end
+    end
+  end
+end

--- a/spec/determinator/retrieve/http_retreiver_spec.rb
+++ b/spec/determinator/retrieve/http_retreiver_spec.rb
@@ -1,12 +1,14 @@
-require 'determinator/retrieve/dynaconf'
+require 'determinator/retrieve/http_retriever'
 require 'spec_helper'
 require 'webmock/rspec'
 
-RSpec.describe Determinator::Retrieve::Dynaconf do
+RSpec.describe Determinator::Retrieve::HttpRetriever do
   describe '#retrieve' do
     subject(:retrieve) { described_class.new(params).retrieve(feature_id) }
-
-    let(:base_url) { 'http://DYNACONF_HOST:4343' }
+    let(:client){
+      Faraday.new(base_url)
+    }
+    let(:base_url) { 'http://actortracking.dev' }
     let(:service_name) { 'MY-SERVICE' }
     let(:feature_id) { 'some-feature' }
     let(:feature_json) { {
@@ -20,20 +22,12 @@ RSpec.describe Determinator::Retrieve::Dynaconf do
       active: true,
       overrides: {}
     } }
-    let(:expected_url) { "#{base_url}/scopes/florence-#{feature_id}/feature" }
-
-    context 'when client is not injected' do
-      let(:params) { { base_url: base_url, service_name: service_name } }
-
-      include_examples 'retrieve tests'
-    end
+    let(:expected_url) { "#{base_url}/features/#{feature_id}" }
 
     context 'when client is injected' do
-      let(:params) { { base_url: base_url, service_name: service_name, client: client } }
+      let(:params) { { connection: client } }
 
       context 'when the client is a Faraday connection' do
-        let(:client) { Faraday.new }
-
         include_examples 'retrieve tests'
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+Dir["./spec/support/**/*.rb"].each {|f| require f}
 require 'determinator'
 require 'factory_girl'
 require 'rspec/its'

--- a/spec/support/retreiver_spec.rb
+++ b/spec/support/retreiver_spec.rb
@@ -1,0 +1,46 @@
+shared_examples 'retrieve tests' do
+  before do
+    allow(Determinator).to receive(:notice_error)
+    stub_request(:get, expected_url).
+      to_return(status: response_status, body: feature_json.to_json)
+  end
+
+  context 'when the feature is found' do
+    let(:response_status) { 200 }
+
+    context 'when there is no other error' do
+      it 'returns a Feature object' do
+        expect(retrieve).to be_a(Determinator::Feature)
+      end
+
+      it 'sets the properties on the object' do
+        expect(retrieve.name).to eql(feature_json[:name])
+      end
+    end
+
+    context 'when an error occurs' do
+      let(:error) { StandardError.new }
+
+      before do
+        allow(Determinator::Serializers::JSON).to receive(:load).and_raise(error)
+        retrieve
+      end
+
+      it 'logs the error' do
+        expect(Determinator).to have_received(:notice_error).with(error)
+      end
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  context 'when the feature is not found' do
+    let(:response_status) { 404 }
+
+    before do
+      retrieve
+    end
+
+    it { is_expected.to be nil }
+  end
+end


### PR DESCRIPTION
Since 2.0 removed the dependency on RoutemasterCaache it's no longer possible to do routemaster style cache invalidation. One of the migration paths out into kafka is to use this pattern.

This PR adds a HttpRetriever and a tiered caching solution that makes it easier to use determinatior with some sort of bus.