### PR TITLE
Add support for app_version property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# HEAD
+
+Feature:
+- Adds support for `app_version` constraints (#60)
+
 # v2.1.0 (2019-05-01)
 
 Feature:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ determinator.which_variant(:my_experiment_name)
 
 Check the example Rails app in the `examples` directory for more information on how to make use of this gem.
 
+### app_version constraint
+
+Feature flags and experiments can also be limited to actors with a [semantic versioning](https://semver.org/) property using an `app_version` property:
+```ruby
+variant = determinator.which_variant(
+  :my_experiment_name,
+  properties: {
+    app_version: "1.2.3"
+  }
+)
+``` 
+The `app_version` constraint for that flag needs to follow ruby gem version constraints. We support the following operators: `>, <, >=, <=, ~>`. For example:
+`app_version: ">=1.2.0"`
+
 ### Using Determinator in RSpec
 
 * Include the  `spec_helper.rb`.


### PR DESCRIPTION
Prior to this change, Determinator didn't allow to do semver comparison on constraints. Without this it was hard to target a certain feature to a certain set of apps.

This change adds support for a new kind of constraint, app_version. An app_version constraint can be set this way:
app_version => [">=1.2.3", "<=1.3"]

The property passed to determinator would be with the following format:
app_version => ["1.2.4"]