### PR TITLE
fake determinator support for app version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 *.gem
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,52 +1,7 @@
-# v??? (2019-08-20)
-
-⚠️ This release includes breaking changes to `RSpec::Determinator` ⚠️
-
-`RSpec::Determinator` now uses the same determination implementation as normal
-determination calls. `RSpec::Determinator` previously used its own
-determination implementation that allowed stacking multiple
-`forced_determination` calls like so:
-
-```ruby
-forced_determination('my-feature-flag', true, only_for: { 'good-actor': true })
-forced_determination('my-feature-flag', false, only_for: { 'bad-actor': true })
-
-context 'good actors' do
-  subject { Determinator.instance.feature_flag_on?(properties: { 'good-actor': true }) }
-  it { is_expected.to be true }
-end
-
-context 'bad actors' do
-  subject { Determinator.instance.feature_flag_on?(properties: { 'bad-actor': true }) }
-  it { is_expected.to be false }
-end
-```
-
-Determinator features don't _quite_ work this way - you can't specify
-constraints that force a negative determinator result (or a particular
-variant). In `RSpec::Determinator` as of this version, the second
-`forced_determination` call will override the `my-feature-flag` feature from
-the first call, and everything will be 
-
-For the above example, you would have to trust determinator's default-to-false
-property rather than explicitly setting it:
-
-```ruby
-forced_determination('my-feature-flag', true, only_for: { 'good-actor': true })
-
-context 'good actors' do
-  subject { Determinator.instance.feature_flag_on?(properties: { 'good-actor': true }) }
-  it { is_expected.to be true }
-end
-
-context 'everyone else' do
-  subject { Determinator.instance.feature_flag_on? }
-  it { is_expected.to be false }
-end
-```
+# Next version
 
 Feature:
-- `RSpec::Determinator` can apply `app_version` constraints
+- `RSpec::Determinator` can apply `app_version` constraints but no longer supports multiple `forced_determination` calls on the same feature. [See the PR for an in-depth write-up.](https://github.com/deliveroo/determinator/pull/63)
 
 # v2.2.1 (2019-07-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,53 @@
+# v??? (2019-08-20)
+
+⚠️ This release includes breaking changes to `RSpec::Determinator` ⚠️
+
+`RSpec::Determinator` now uses the same determination implementation as normal
+determination calls. `RSpec::Determinator` previously used its own
+determination implementation that allowed stacking multiple
+`forced_determination` calls like so:
+
+```ruby
+forced_determination('my-feature-flag', true, only_for: { 'good-actor': true })
+forced_determination('my-feature-flag', false, only_for: { 'bad-actor': true })
+
+context 'good actors' do
+  subject { Determinator.instance.feature_flag_on?(properties: { 'good-actor': true }) }
+  it { is_expected.to be true }
+end
+
+context 'bad actors' do
+  subject { Determinator.instance.feature_flag_on?(properties: { 'bad-actor': true }) }
+  it { is_expected.to be false }
+end
+```
+
+Determinator features don't _quite_ work this way - you can't specify
+constraints that force a negative determinator result (or a particular
+variant). In `RSpec::Determinator` as of this version, the second
+`forced_determination` call will override the `my-feature-flag` feature from
+the first call, and everything will be 
+
+For the above example, you would have to trust determinator's default-to-false
+property rather than explicitly setting it:
+
+```ruby
+forced_determination('my-feature-flag', true, only_for: { 'good-actor': true })
+
+context 'good actors' do
+  subject { Determinator.instance.feature_flag_on?(properties: { 'good-actor': true }) }
+  it { is_expected.to be true }
+end
+
+context 'everyone else' do
+  subject { Determinator.instance.feature_flag_on? }
+  it { is_expected.to be false }
+end
+```
+
+Feature:
+- `RSpec::Determinator` can apply `app_version` constraints
+
 # v2.2.1 (2019-07-29)
 
 Bug fix:

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -1,6 +1,7 @@
 require 'digest/md5'
 require 'determinator/actor_control'
 require 'semantic'
+require 'securerandom'
 
 module Determinator
   class Control

--- a/lib/determinator/retrieve/in_memory_retriever.rb
+++ b/lib/determinator/retrieve/in_memory_retriever.rb
@@ -1,0 +1,23 @@
+module Determinator
+  module Retrieve
+
+    # An retriever that returns features that were previously stored
+    # in the retriever. Useful for testing.
+    class InMemoryRetriever
+      def initialize
+        @features = {}
+      end
+
+      # @param name [string,symbol] The name of the feature to retrieve
+      def retrieve(name)
+        @features[name.to_s]
+      end
+
+      # @param feature [Determinator::Feature] The feature to store
+      def store(feature)
+        @features[feature.name] = feature
+      end
+    end
+
+  end
+end

--- a/lib/determinator/retrieve/in_memory_retriever.rb
+++ b/lib/determinator/retrieve/in_memory_retriever.rb
@@ -17,6 +17,10 @@ module Determinator
       def store(feature)
         @features[feature.name] = feature
       end
+
+      def clear!
+        @features.clear
+      end
     end
 
   end

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -10,6 +10,7 @@ module RSpec
       by.around do |example|
         old_retriever = ::Determinator.instance.retrieval
         begin
+          fake_retriever.clear!
           ::Determinator.configure(retrieval: fake_retriever)
           example.run
         ensure

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -67,7 +67,7 @@ module RSpec
                    end
         target_group = ::Determinator::TargetGroup.new(
           rollout: 65_536,
-          constraints: only_for.map { |key, value| [key.to_s, value.to_s] }.to_h
+          constraints: only_for.map { |key, value| [key.to_s, Array(value).map(&:to_s)] }.to_h
         )
 
         feature = ::Determinator::Feature.new(

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -1,13 +1,20 @@
 require 'determinator'
+require_relative '../determinator/retrieve/in_memory_retriever'
 
 module RSpec
   module Determinator
     def self.included(by)
       by.extend(DSL)
 
-      by.let(:fake_determinator) { FakeControl.new }
-      by.before do
-        allow(::Determinator).to receive(:instance).and_return(fake_determinator)
+      by.let(:fake_retriever) { ::Determinator::Retrieve::InMemoryRetriever.new }
+      by.around do |example|
+        old_retriever = ::Determinator.instance.retrieval
+        begin
+          ::Determinator.configure(retrieval: fake_retriever)
+          example.run
+        ensure
+          ::Determinator.configure(retrieval: old_retriever)
+        end
       end
     end
 
@@ -26,53 +33,28 @@ module RSpec
           outcome = send(outcome) if outcome.is_a?(Symbol)
           only_for = send(only_for) if only_for.is_a?(Symbol)
 
-          fake_determinator.mock_result(
-            name,
-            outcome,
-            only_for: only_for
+          active = !!outcome
+          variants = case outcome
+                     when true, false then
+                       []
+                     else
+                       { outcome => 1 }
+                     end
+          target_group = ::Determinator::TargetGroup.new(
+            rollout: 65_536,
+            constraints: Hash[only_for.map { |key, value| [key.to_s, value] }]
           )
-        end
-      end
-    end
 
-    class FakeControl
-      def initialize
-        @mocked_results = Hash.new { |h, k| h[k] = {} }
-      end
+          feature = ::Determinator::Feature.new(
+            name: name.to_s,
+            identifier: name.to_s,
+            bucket_type: 'single',
+            active: active,
+            variants: variants,
+            target_groups: [target_group]
+          )
 
-      def for_actor(**args)
-        ::Determinator::ActorControl.new(self, **args)
-      end
-
-      def mock_result(name, result, only_for: {})
-        @mocked_results[name.to_s][normalize_properties(only_for)] = result
-      end
-
-      def fake_determinate(name, id: nil, guid: nil, properties: {})
-        properties[:id] = id if id
-        properties[:guid] = guid if guid
-
-        outcome_for_feature_given_properties(name.to_s, normalize_properties(properties))
-      end
-      alias_method :feature_flag_on?, :fake_determinate
-      alias_method :which_variant, :fake_determinate
-
-      private
-
-      def outcome_for_feature_given_properties(feature_name, requirements)
-        req_array = requirements.to_a
-
-        keys_in_priority_order = @mocked_results[feature_name].keys.reverse
-        key = keys_in_priority_order.find do |given|
-          (given.to_a - req_array).empty?
-        end
-
-        @mocked_results[feature_name][key] || false
-      end
-
-      def normalize_properties(properties)
-        properties.each_with_object({}) do |(key, value), hash|
-          hash[key.to_s] = [*value].map(&:to_s)
+          fake_retriever.store(feature)
         end
       end
     end

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -56,7 +56,7 @@ module RSpec
                    end
         target_group = ::Determinator::TargetGroup.new(
           rollout: 65_536,
-          constraints: Hash[only_for.map { |key, value| [key.to_s, value] }]
+          constraints: only_for.map { |key, value| [key.to_s, value.to_s] }.to_h
         )
 
         feature = ::Determinator::Feature.new(

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -95,6 +95,13 @@ describe RSpec::Determinator, :determinator_support do
       it { should eq 'outcome' }
     end
 
+    context 'when forcing a determination for array constraints' do
+      forced_determination(:my_experiment, 'outcome', only_for: { attribute: %w(thing-a thing-b) })
+      let(:properties) { { attribute: 'thing-b' } }
+
+      it { should eq 'outcome' }
+    end
+
     context 'when using an ActorControl proxy' do
       let(:determinator) { Determinator.instance.for_actor(id: 123) }
       subject(:determination) { determinator.which_variant(:my_experiment, properties: properties) }

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -8,7 +8,9 @@ describe RSpec::Determinator, :determinator_support do
   subject(:determinator) { Determinator.instance }
 
   describe 'the determination for the experiment' do
-    subject(:determination) { determinator.which_variant(:my_experiment, properties: properties) }
+    subject(:determination) { determinator.which_variant(:my_experiment, id: id, guid: guid, properties: properties) }
+    let(:id) { nil }
+    let(:guid) { nil }
     let(:properties) { {} }
 
     context 'when not forcing a determination' do
@@ -86,8 +88,16 @@ describe RSpec::Determinator, :determinator_support do
       it { should eq 'second outcome' }
     end
 
+    context 'when forcing a determination for array constraints' do
+      forced_determination(:my_experiment, 'outcome', only_for: { attribute: %w(thing-a thing-b) })
+      let(:properties) { { attribute: 'thing-b' } }
+
+      it { should eq 'outcome' }
+    end
+
     context 'when using an ActorControl proxy' do
       let(:determinator) { Determinator.instance.for_actor(id: 123) }
+      subject(:determination) { determinator.which_variant(:my_experiment, properties: properties) }
 
       context 'when not forcing a determination' do
         it { should eq false }

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -35,6 +35,13 @@ describe RSpec::Determinator, :determinator_support do
       it { should eq 'outcome' }
     end
 
+    context 'when forcing a determination for actors with specific numeric properties' do
+      forced_determination(:my_experiment, 'outcome', only_for: { 1 => 2 })
+      let(:properties) { { 1 => 2 } }
+
+      it { should eq 'outcome' }
+    end
+
     context 'when forcing a determination for actors with specific properties that match when the forced determination needs to be normalized' do
       forced_determination(:my_experiment, 'outcome', only_for: { 'property' => 'correct' })
       let(:properties) { { property: 'correct' } }


### PR DESCRIPTION
Currently `RSpec::Determinator` uses a separate implementation of determination for features and variants that does not support the new `app_version` constraint property.

This PR changes `RSpec::Determinator` so that instead of using a stub determinator implementation it uses the real determinator and injects features using an in-memory feature repository that is cleared out between specs.

This can make testing some cases harder, but there's an advantage in that you'll find out if your feature constraints will actually work in your tests rather than when you go to configure them in staging for the first time.

This breaks some Orderweb specs - I have an [Orderweb PR](/deliveroo/orderweb/pull/14780) that addresses these breakages.

A worked example of the change - previously `RSpec::Determinator` allowed stacking multiple `forced_determination` calls like so:

```ruby
forced_determination('my-feature-flag', true, only_for: { 'good-actor': true })
forced_determination('my-feature-flag', false, only_for: { 'bad-actor': true })

context 'good actors' do
  subject { Determinator.instance.feature_flag_on?(properties: { 'good-actor': true }) }
  it { is_expected.to be true }
end

context 'bad actors' do
  subject { Determinator.instance.feature_flag_on?(properties: { 'bad-actor': true }) }
  it { is_expected.to be false }
end
```

Determinator features don't _quite_ work this way - you can't specify constraints that force a negative determinator result (or a particular variant). In `RSpec::Determinator` as of this version, the second `forced_determination` call will override the `my-feature-flag` feature from the first call, and everything will be 

For the above example, you would have to trust determinator's default-to-false
property rather than explicitly setting it:

```ruby
forced_determination('my-feature-flag', true, only_for: { 'good-actor': true })

context 'good actors' do
  subject { Determinator.instance.feature_flag_on?(properties: { 'good-actor': true }) }
  it { is_expected.to be true }
end

context 'everyone else' do
  subject { Determinator.instance.feature_flag_on? }
  it { is_expected.to be false }
end
```