### PR TITLE
Introduce a setting allowing the user to control if 404s should be cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+Feature:
+- Add a flag `cache_missing[true]` to the cache wrapper to control the cache behaviour on 404
+
+Bug fix:
+- Ensure errors are not cached by the cache wrapper
+
 # v2.3.0 (2019-09-06)
 
 Feature:

--- a/lib/determinator.rb
+++ b/lib/determinator.rb
@@ -4,6 +4,9 @@ require 'determinator/feature'
 require 'determinator/target_group'
 require 'determinator/cache/fetch_wrapper'
 require 'determinator/serializers/json'
+require 'determinator/missing_response'
+require 'determinator/error_response'
+
 
 module Determinator
   class << self

--- a/lib/determinator/cache/fetch_wrapper.rb
+++ b/lib/determinator/cache/fetch_wrapper.rb
@@ -21,7 +21,7 @@ module Determinator
         return value if !value.nil? && !(value.is_a?(MissingResponse) && !@cache_missing)
 
         value_to_write = yield
-        return value_to_write if value.is_a?(ErrorResponse)
+        return value_to_write if value_to_write.is_a?(ErrorResponse)
         @caches.each do |cache|
           cache.write(key(feature_name), value_to_write)
         end

--- a/lib/determinator/cache/fetch_wrapper.rb
+++ b/lib/determinator/cache/fetch_wrapper.rb
@@ -44,7 +44,7 @@ module Determinator
       # in that list will be backfilled.
       #
       # @param url [String] a feature name
-      # @return [Feature, MissingResponse] nil when no value is found, otherwise
+      # @return [Feature, MissingResponse] nil when no value is found
       def read_and_upfill(feature_name)
         @caches.each.with_index do |cache, index|
           if cache.exist?(key(feature_name))

--- a/lib/determinator/cache/fetch_wrapper.rb
+++ b/lib/determinator/cache/fetch_wrapper.rb
@@ -4,7 +4,8 @@ module Determinator
       # @param *caches [ActiveSupport::Cache] If a list then the head of the the
       # list should will be checked before the  tail. If the head is empty but
       # the tail is not then the head will be filled with the value of the tail.
-      def initialize(*caches)
+      def initialize(*caches, cache_missing: true)
+        @cache_missing = cache_missing
         @caches = caches
       end
 
@@ -13,8 +14,8 @@ module Determinator
       def call(feature_name)
         value = read_and_upfill(feature_name)
         # nil is an acceptable value in the case of a missing feature definition
-        return nil if value.nil?
-        return value if value != false
+        return nil if value.nil? && @cache_missing
+        return value if value != false && !value.nil?
 
         value_to_write = yield
         @caches.each do |cache|

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -62,7 +62,7 @@ module Determinator
     def determinate_and_notice(name, id:, guid:, properties:)
       feature = Determinator.with_retrieval_cache(name) { retrieval.retrieve(name) }
 
-      if feature.nil?
+      if !feature
         Determinator.notice_missing_feature(name)
         return false
       end

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -62,9 +62,9 @@ module Determinator
     def determinate_and_notice(name, id:, guid:, properties:)
       feature = Determinator.with_retrieval_cache(name) { retrieval.retrieve(name) }
 
-      if !feature
+      if feature.is_a?(ErrorResponse) || feature.is_a?(MissingResponse)
         Determinator.notice_missing_feature(name)
-        return false
+        return nil
       end
 
       determinate(feature, id: id, guid: guid, properties: properties).tap do |determination|

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -62,9 +62,9 @@ module Determinator
     def determinate_and_notice(name, id:, guid:, properties:)
       feature = Determinator.with_retrieval_cache(name) { retrieval.retrieve(name) }
 
-      if feature.is_a?(ErrorResponse) || feature.is_a?(MissingResponse)
+      if feature.nil? || feature.is_a?(ErrorResponse) || feature.is_a?(MissingResponse)
         Determinator.notice_missing_feature(name)
-        return nil
+        return false
       end
 
       determinate(feature, id: id, guid: guid, properties: properties).tap do |determination|

--- a/lib/determinator/error_response.rb
+++ b/lib/determinator/error_response.rb
@@ -1,0 +1,1 @@
+class ErrorResponse; end

--- a/lib/determinator/error_response.rb
+++ b/lib/determinator/error_response.rb
@@ -1,1 +1,3 @@
-class ErrorResponse; end
+module Determinator
+  class ErrorResponse; end
+end

--- a/lib/determinator/missing_response.rb
+++ b/lib/determinator/missing_response.rb
@@ -1,1 +1,3 @@
-class MissingResponse; end
+module Determinator
+  class MissingResponse; end
+end

--- a/lib/determinator/missing_response.rb
+++ b/lib/determinator/missing_response.rb
@@ -1,0 +1,1 @@
+class MissingResponse; end

--- a/lib/determinator/retrieve/dynaconf.rb
+++ b/lib/determinator/retrieve/dynaconf.rb
@@ -18,10 +18,10 @@ module Determinator
       def retrieve(feature_id)
         response = get(feature_id)
         return Determinator::Serializers::JSON.load(response.body) if response.status == 200
-        return nil if response.status == 404
+        return MissingResponse.new if response.status == 404
       rescue => e
         Determinator.notice_error(e)
-        false
+        ErrorResponse.new
       end
 
       private

--- a/lib/determinator/retrieve/dynaconf.rb
+++ b/lib/determinator/retrieve/dynaconf.rb
@@ -16,13 +16,11 @@ module Determinator
       end
 
       def retrieve(feature_id)
-        begin
-          response = get(feature_id)
-          return Determinator::Serializers::JSON.load(response.body) if response.status == 200
-          return nil if response.status == 404
-        rescue => e
-          Determinator.notice_error(e)
-        end
+        response = get(feature_id)
+        return Determinator::Serializers::JSON.load(response.body) if response.status == 200
+        return nil if response.status == 404
+      rescue => e
+        Determinator.notice_error(e)
         false
       end
 

--- a/lib/determinator/retrieve/dynaconf.rb
+++ b/lib/determinator/retrieve/dynaconf.rb
@@ -16,11 +16,14 @@ module Determinator
       end
 
       def retrieve(feature_id)
-        response = get(feature_id)
-        Determinator::Serializers::JSON.load(response.body) if response.status == 200
-      rescue => e
-        Determinator.notice_error(e)
-        nil
+        begin
+          response = get(feature_id)
+          return Determinator::Serializers::JSON.load(response.body) if response.status == 200
+          return nil if response.status == 404
+        rescue => e
+          Determinator.notice_error(e)
+        end
+        false
       end
 
       private

--- a/lib/determinator/retrieve/file.rb
+++ b/lib/determinator/retrieve/file.rb
@@ -13,11 +13,11 @@ module Determinator
 
       def retrieve(feature_id)
         feature = @root.join(feature_id.to_s)
-        return unless feature.exist?
+        return MissingResponse.new unless feature.exist?
         @serializer.load(feature.read)
       rescue => e
         Determinator.notice_error(e)
-        nil
+        ErrorResponse.new
       end
     end
   end

--- a/lib/determinator/retrieve/http_retriever.rb
+++ b/lib/determinator/retrieve/http_retriever.rb
@@ -13,10 +13,11 @@ module Determinator
         begin
           response = @connection.get("/features/#{name}")
           return Determinator::Serializers::JSON.load(response.body) if response.status == 200
+          return nil if response.status == 404
         rescue => e
           Determinator.notice_error(e)
         end
-        nil
+        false
       end
 
       # Returns a feature name given a actor-tracking url. Used so we are able

--- a/lib/determinator/retrieve/http_retriever.rb
+++ b/lib/determinator/retrieve/http_retriever.rb
@@ -12,10 +12,10 @@ module Determinator
       def retrieve(name)
         response = @connection.get("/features/#{name}")
         return Determinator::Serializers::JSON.load(response.body) if response.status == 200
-        return nil if response.status == 404
+        return MissingResponse.new if response.status == 404
       rescue => e
         Determinator.notice_error(e)
-        false
+        ErrorResponse.new
       end
 
       # Returns a feature name given a actor-tracking url. Used so we are able

--- a/lib/determinator/retrieve/http_retriever.rb
+++ b/lib/determinator/retrieve/http_retriever.rb
@@ -10,13 +10,11 @@ module Determinator
       end
 
       def retrieve(name)
-        begin
-          response = @connection.get("/features/#{name}")
-          return Determinator::Serializers::JSON.load(response.body) if response.status == 200
-          return nil if response.status == 404
-        rescue => e
-          Determinator.notice_error(e)
-        end
+        response = @connection.get("/features/#{name}")
+        return Determinator::Serializers::JSON.load(response.body) if response.status == 200
+        return nil if response.status == 404
+      rescue => e
+        Determinator.notice_error(e)
         false
       end
 

--- a/spec/determinator/cache/fetch_wrapper_spec.rb
+++ b/spec/determinator/cache/fetch_wrapper_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe Determinator::Cache::FetchWrapper do
     end
 
     context 'when the feature does not exist' do
-      let(:retrieval_response) { nil }
+      let(:retrieval_response) { MissingResponse.new }
 
       context 'when the (absence of the) feature is not in the cache' do
         # No setup required
 
-        it { should eq retrieval_response }
+        it { should be_a MissingResponse }
         it 'should have performed a retrieval' do
           expect{|b| described_instance.call(feature.name, &b)}.to yield_control
         end
@@ -49,7 +49,7 @@ RSpec.describe Determinator::Cache::FetchWrapper do
           described_instance.call(feature.name) { retrieval_response }
         end
 
-        it { should eq retrieval_response }
+        it { should be_a MissingResponse }
         it 'should not have performed a retrieval' do
           expect{|b| described_instance.call(feature.name, &b)}.not_to yield_control
         end

--- a/spec/determinator/cache/fetch_wrapper_spec.rb
+++ b/spec/determinator/cache/fetch_wrapper_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe Determinator::Cache::FetchWrapper do
     end
 
     context 'when the feature does not exist' do
-      let(:retrieval_response) { MissingResponse.new }
+      let(:retrieval_response) { Determinator::MissingResponse.new }
 
       context 'when the (absence of the) feature is not in the cache' do
         # No setup required
 
-        it { should be_a MissingResponse }
+        it { should be_a Determinator::MissingResponse }
         it 'should have performed a retrieval' do
           expect{|b| described_instance.call(feature.name, &b)}.to yield_control
         end
@@ -49,7 +49,7 @@ RSpec.describe Determinator::Cache::FetchWrapper do
           described_instance.call(feature.name) { retrieval_response }
         end
 
-        it { should be_a MissingResponse }
+        it { should be_a Determinator::MissingResponse }
         it 'should not have performed a retrieval' do
           expect{|b| described_instance.call(feature.name, &b)}.not_to yield_control
         end

--- a/spec/determinator/cache/fetch_wrapper_spec.rb
+++ b/spec/determinator/cache/fetch_wrapper_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe Determinator::Cache::FetchWrapper do
       end
     end
 
+    context "if there is an error response" do
+      let(:retrieval_response) { Determinator::ErrorResponse.new }
+
+      it "should populate any caches" do
+        [caches].flatten.each do |cache|
+          expect(cache).not_to receive(:write)
+        end
+        subject
+      end
+    end
+
     context 'when the feature does not exist' do
       let(:retrieval_response) { Determinator::MissingResponse.new }
 

--- a/spec/determinator/cache/fetch_wrapper_spec.rb
+++ b/spec/determinator/cache/fetch_wrapper_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe Determinator::Cache::FetchWrapper do
         it 'should not have performed a retrieval' do
           expect{|b| described_instance.call(feature.name, &b)}.not_to yield_control
         end
+
+        context 'and cached nils are off' do
+          let(:described_instance) { described_class.new(*caches, cache_missing: false) }
+          it { should eq retrieval_response }
+          it 'should have performed a retrieval' do
+            expect{|b| described_instance.call(feature.name, &b)}.to yield_control
+          end
+        end
       end
     end
   end
@@ -91,6 +99,4 @@ RSpec.describe Determinator::Cache::FetchWrapper do
     let(:caches) { ActiveSupport::Cache::MemoryStore.new(expires_in: 1.minute) }
     it_behaves_like "a cache"
   end
-
-
 end

--- a/spec/support/retreiver_spec.rb
+++ b/spec/support/retreiver_spec.rb
@@ -30,7 +30,7 @@ shared_examples 'retrieve tests' do
         expect(Determinator).to have_received(:notice_error).with(error)
       end
 
-      it { is_expected.to be nil }
+      it { is_expected.to be false }
     end
   end
 

--- a/spec/support/retreiver_spec.rb
+++ b/spec/support/retreiver_spec.rb
@@ -30,7 +30,7 @@ shared_examples 'retrieve tests' do
         expect(Determinator).to have_received(:notice_error).with(error)
       end
 
-      it { is_expected.to be false }
+      it { is_expected.to be_a ErrorResponse }
     end
   end
 
@@ -41,6 +41,6 @@ shared_examples 'retrieve tests' do
       retrieve
     end
 
-    it { is_expected.to be nil }
+    it { is_expected.to be_a MissingResponse }
   end
 end

--- a/spec/support/retreiver_spec.rb
+++ b/spec/support/retreiver_spec.rb
@@ -30,7 +30,7 @@ shared_examples 'retrieve tests' do
         expect(Determinator).to have_received(:notice_error).with(error)
       end
 
-      it { is_expected.to be_a ErrorResponse }
+      it { is_expected.to be_a Determinator::ErrorResponse }
     end
   end
 
@@ -41,6 +41,6 @@ shared_examples 'retrieve tests' do
       retrieve
     end
 
-    it { is_expected.to be_a MissingResponse }
+    it { is_expected.to be_a Determinator::MissingResponse }
   end
 end


### PR DESCRIPTION
In instances where a connection to the actor tracking server may be unreliable you wouldn't want to cache all 404s so this pr introduces a new setting to turn that off.

Also, this pr makes a distinction between errors and 404 when communicating with an upstream service either by http or dynaconf.