### PR TITLE
Make `RSpec::Determinator` clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Determinator.configure(retrieval: nil)
 
 * Tag your rspec test with `:determinator_support`, so the `forced_determination` helper method will be available.
 
-  Please note, `RSpec::Determinator` mocks a determination _outcome_, not the process of choosing an outcome. Set the `only_for` argument to be the required properties for Determinator to return the specified outcome.
+  Please note, `RSpec::Determinator` mocks a determination _outcome_, not the process of choosing one. Set the `only_for` argument to be the properties you require for Determinator to return the specified outcome. At the moment this mock does not allow for the testing of the `id` or `guid` arguments (only the properties).
 
 ```ruby
 RSpec.describe "something", :determinator_support do

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Determinator.configure(retrieval: nil)
 
 * Tag your rspec test with `:determinator_support`, so the `forced_determination` helper method will be available.
 
+  Please note, `RSpec::Determinator` mocks a determination _outcome_, not the process of choosing an outcome. Set the `only_for` argument to be the required properties for Determinator to return the specified outcome.
+
 ```ruby
 RSpec.describe "something", :determinator_support do
 


### PR DESCRIPTION
The `only_for` argument has caused an engineer some confusion recently — this readme change may prevent similar confusions in the future.