### PR TITLE
Add tracking middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Feature:
+- Add tracker middleware
+
 # v2.3.1 (2019-05-25)
 
 Feature:

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ variant = determinator.which_variant(
     app_version: "1.2.3"
   }
 )
-``` 
+```
 The `app_version` constraint for that flag needs to follow ruby gem version constraints. We support the following operators: `>, <, >=, <=, ~>`. For example:
 `app_version: ">=1.2.0"`
 
@@ -250,6 +250,35 @@ end
 ```
 
 * Check out [the specs for `RSpec::Determinator`](spec/rspec/determinator_spec.rb) to find out what you can do!
+
+## Tracking
+
+The library includes a middleware to track all determinations being made, allowing logging them at the end of the request
+(including some useful request metrics).
+
+To enable it, e.g. in Rails:
+
+```ruby
+# config/application.rb
+
+require 'determinator/tracking/rack/middleware'
+
+# possibly near the top of your stack, in case other middlewares make determinations
+config.middleware.use Determinator::Tracking::Rack::Middleware
+```
+
+```ruby
+# config/initializers/determinator.rb
+
+require 'determinator/tracking'
+
+Determinator::Tracking.on_request do |r|
+  Rails.logger.info("Request time: #{r.time}, error: #{r.error?}, status: #{r.attributes[:status]}")
+  request.determinations.each do |d|
+    Rails.logger.info("Determination id: #{d.id}, guid: #{d.guid}, flag: #{d.feature_id}, result: #{d.determination}")
+  end
+end
+```
 
 ## Testing this library
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,9 @@ Determinator::Tracking.get_context do
   Determinator::Tracking::Context.new(
     request_id: span.trace_id,
     service: span.service,
-    resource: span.resource
+    resource: span.resource,
+    type: span.type,
+    meta: span.meta
   )
 end
 ```

--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ config.middleware.use Determinator::Tracking::Rack::Middleware
 require 'determinator/tracking'
 
 Determinator::Tracking.on_request do |r|
-  Rails.logger.info("Request time: #{r.time}, error: #{r.error?}, status: #{r.attributes[:status]}")
+  Rails.logger.info("tag=determinator_request request_time=#{r.time} error=#{r.error?} status=#{r.attributes[:status]}")
   r.determinations.each do |d|
-    Rails.logger.info("Determination id: #{d.id}, guid: #{d.guid}, flag: #{d.feature_id}, result: #{d.determination}")
+    Rails.logger.info("tag=determination id=#{d.id} guid=#{d.guid} flag=#{d.feature_id} result=#{d.determination}")
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -272,10 +272,6 @@ config.middleware.use Determinator::Tracking::Rack::Middleware
 
 require 'determinator/tracking'
 
-Determinator.on_determination do |id, guid, feature, determination|
-  Determinator::Tracking.track(id, guid, feature, determination)
-end
-
 Determinator::Tracking.on_request do |r|
   Rails.logger.info("Request time: #{r.time}, error: #{r.error?}, status: #{r.attributes[:status]}")
   request.determinations.each do |d|

--- a/README.md
+++ b/README.md
@@ -294,6 +294,13 @@ Determinator::Tracking.get_context do
 end
 ```
 
+NOTE: this is implemented by keeping the list of requests in a per-request thread-local variable, which means that determinations will only be tracked on the main thread.
+
+If your application is spinning out worker threads, you should make the determinations in the main thread if possible; or collect them from your worker threads and track them in the main thread with
+```
+Determinator::Tracking.track(id, guid, feature, determination)
+```
+
 ## Testing this library
 
 This library makes use of the [Determinator Standard Tests](https://github.com/deliveroo/determinator-standard-tests) to ensure that it conforms to the same specification as determinator libraries in other languages. The standard tests can be updated to the latest ones available by updating the submodule:

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ require 'determinator/tracking'
 
 Determinator::Tracking.on_request do |r|
   Rails.logger.info("Request time: #{r.time}, error: #{r.error?}, status: #{r.attributes[:status]}")
-  request.determinations.each do |d|
+  r.determinations.each do |d|
     Rails.logger.info("Determination id: #{d.id}, guid: #{d.guid}, flag: #{d.feature_id}, result: #{d.determination}")
   end
 end

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ config.middleware.use Determinator::Tracking::Rack::Middleware
 
 require 'determinator/tracking'
 
+Determinator.on_determination do |id, guid, feature, determination|
+  Determinator::Tracking.track(id, guid, feature, determination)
+end
+
 Determinator::Tracking.on_request do |r|
   Rails.logger.info("Request time: #{r.time}, error: #{r.error?}, status: #{r.attributes[:status]}")
   request.determinations.each do |d|

--- a/README.md
+++ b/README.md
@@ -267,13 +267,27 @@ require 'determinator/tracking/rack/middleware'
 config.middleware.use Determinator::Tracking::Rack::Middleware
 ```
 
+or for Sidekiq:
+
+```ruby
+# config/initializers/sidekiq.rb
+
+require 'determinator/tracking/sidekiq/middleware'
+
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add Determinator::Tracking::Sidekiq::Middleware
+  end
+end
+```
+
 ```ruby
 # config/initializers/determinator.rb
 
 require 'determinator/tracking'
 
 Determinator::Tracking.on_request do |r|
-  Rails.logger.info("tag=determinator_request request_time=#{r.time} error=#{r.error?} status=#{r.attributes[:status]}")
+  Rails.logger.info("tag=determinator_request type=#{r.type} request_time=#{r.time} error=#{r.error?} response_status=#{r.attributes[:status]} sidekiq_queue=#{r.attributes[:queue]}")
   r.determinations.each do |d|
     Rails.logger.info("tag=determination id=#{d.id} guid=#{d.guid} flag=#{d.feature_id} result=#{d.determination}")
   end

--- a/README.md
+++ b/README.md
@@ -278,6 +278,18 @@ Determinator::Tracking.on_request do |r|
     Rails.logger.info("Determination id: #{d.id}, guid: #{d.guid}, flag: #{d.feature_id}, result: #{d.determination}")
   end
 end
+
+# If using an APM, you can provide trace information on the request by providing a get_context hook: e.g.
+
+Determinator::Tracking.get_context do
+  span = Datadog.tracer.active_root_span
+  return unless span
+  Determinator::Tracking::Context.new(
+    request_id: span.trace_id,
+    service: span.service,
+    resource: span.resource
+  )
+end
 ```
 
 ## Testing this library

--- a/determinator.gemspec
+++ b/determinator.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec", "~> 4.7"
   spec.add_development_dependency "factory_girl", "~> 4.8"
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency "sidekiq"
 end

--- a/lib/determinator.rb
+++ b/lib/determinator.rb
@@ -6,6 +6,7 @@ require 'determinator/cache/fetch_wrapper'
 require 'determinator/serializers/json'
 require 'determinator/missing_response'
 require 'determinator/error_response'
+require 'determinator/tracking'
 
 
 module Determinator
@@ -83,6 +84,7 @@ module Determinator
     end
 
     def notice_determination(id, guid, feature, determination)
+      Determinator::Tracking.track(id, guid, feature, determination)
       return unless @determination_callback
       @determination_callback.call(id, guid, feature, determination)
     end

--- a/lib/determinator/tracking.rb
+++ b/lib/determinator/tracking.rb
@@ -1,4 +1,5 @@
 require 'determinator/tracking/tracker'
+require 'determinator/tracking/context'
 
 module Determinator
   module Tracking
@@ -36,13 +37,25 @@ module Determinator
         @on_request = block
       end
 
-      def clear_on_request!
-        @on_request
-      end
-
       def report(request)
         return unless @on_request
         @on_request.call(request)
+      end
+
+      def get_context(&block)
+        @get_context = block
+      end
+
+      def context
+        return unless @get_context
+        @get_context.call
+      rescue
+        nil
+      end
+
+      def clear_hooks!
+        @on_request = nil
+        @get_context = nil
       end
     end
   end

--- a/lib/determinator/tracking.rb
+++ b/lib/determinator/tracking.rb
@@ -1,0 +1,49 @@
+require 'determinator/tracking/tracker'
+
+module Determinator
+  module Tracking
+    class <<self
+      def instance
+        Thread.current[:determinator_tracker]
+      end
+
+      def start!(type)
+        Thread.current[:determinator_tracker] = Tracker.new(type)
+      end
+
+      def finish!(error:, **attributes)
+        return false unless started?
+        request = instance.finish!(error: error, **attributes)
+        clear!
+        report(request)
+        request
+      end
+
+      def clear!
+        Thread.current[:determinator_tracker] = nil
+      end
+
+      def started?
+        !!instance
+      end
+
+      def track(id, guid, feature, determination)
+        return false unless started?
+        instance.track(id, guid, feature, determination)
+      end
+
+      def on_request(&block)
+        @on_request = block
+      end
+
+      def clear_on_request!
+        @on_request
+      end
+
+      def report(request)
+        return unless @on_request
+        @on_request.call(request)
+      end
+    end
+  end
+end

--- a/lib/determinator/tracking.rb
+++ b/lib/determinator/tracking.rb
@@ -2,7 +2,7 @@ require 'determinator/tracking/tracker'
 
 module Determinator
   module Tracking
-    class <<self
+    class << self
       def instance
         Thread.current[:determinator_tracker]
       end

--- a/lib/determinator/tracking/context.rb
+++ b/lib/determinator/tracking/context.rb
@@ -3,10 +3,12 @@ module Determinator
     class Context
       attr_reader :request_id, :service, :resource
 
-      def initialize(request_id: nil, service: nil, resource: nil)
+      def initialize(request_id: nil, service: nil, resource: nil, type: nil, meta: {})
         @request_id = request_id
         @service = service
         @resource = resource
+        @type = type
+        @meta = meta
       end
     end
   end

--- a/lib/determinator/tracking/context.rb
+++ b/lib/determinator/tracking/context.rb
@@ -1,0 +1,13 @@
+module Determinator
+  module Tracking
+    class Context
+      attr_reader :request_id, :service, :resource
+
+      def initialize(request_id: nil, service: nil, resource: nil)
+        @request_id = request_id
+        @service = service
+        @resource = resource
+      end
+    end
+  end
+end

--- a/lib/determinator/tracking/determination.rb
+++ b/lib/determinator/tracking/determination.rb
@@ -1,0 +1,18 @@
+module Determinator
+  module Tracking
+    class Determination
+      attr_reader :id, :guid, :feature_id, :determination
+
+      def initialize(id:, guid:, feature_id:, determination:)
+        @id = id
+        @guid = guid
+        @feature_id = feature_id
+        @determination = determination
+      end
+
+      def ==(other)
+        id == other.id && guid == other.guid && feature_id == other.feature_id && determination == other.determination
+      end
+    end
+  end
+end

--- a/lib/determinator/tracking/rack/middleware.rb
+++ b/lib/determinator/tracking/rack/middleware.rb
@@ -1,0 +1,24 @@
+require 'determinator/tracking'
+
+module Determinator
+  module Tracking
+    module Rack
+      class Middleware
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          Determinator::Tracking.start!(:rack)
+          status, headers, response = @app.call(env)
+          [status, headers, response]
+        rescue
+          error = true
+          raise
+        ensure
+          Determinator::Tracking.finish!(status: status, error: !!error)
+        end
+      end
+    end
+  end
+end

--- a/lib/determinator/tracking/request.rb
+++ b/lib/determinator/tracking/request.rb
@@ -1,0 +1,19 @@
+module Determinator
+  module Tracking
+    class Request
+      attr_reader :type, :time, :error, :attributes, :determinations
+
+      def initialize(type:, time:, error:, attributes:, determinations:)
+        @type = type
+        @time = time
+        @error = error
+        @attributes = attributes
+        @determinations = determinations
+      end
+
+      def error?
+        error
+      end
+    end
+  end
+end

--- a/lib/determinator/tracking/request.rb
+++ b/lib/determinator/tracking/request.rb
@@ -1,14 +1,15 @@
 module Determinator
   module Tracking
     class Request
-      attr_reader :type, :time, :error, :attributes, :determinations
+      attr_reader :type, :time, :error, :attributes, :determinations, :context
 
-      def initialize(type:, time:, error:, attributes:, determinations:)
+      def initialize(type:, time:, error:, attributes:, determinations:, context: nil)
         @type = type
         @time = time
         @error = error
         @attributes = attributes
         @determinations = determinations
+        @context = context
       end
 
       def error?

--- a/lib/determinator/tracking/sidekiq/middleware.rb
+++ b/lib/determinator/tracking/sidekiq/middleware.rb
@@ -1,0 +1,27 @@
+require 'determinator/tracking'
+
+module Determinator
+  module Tracking
+    module Sidekiq
+      class Middleware
+        # @param [Object] worker the worker instance
+        # @param [Hash] job the full job payload
+        #   * @see https://github.com/mperham/sidekiq/wiki/Job-Format
+        # @param [String] queue the name of the queue the job was pulled from
+        # @yield the next middleware in the chain or worker `perform` method
+        # @return [Void]
+        def call(worker, job, queue)
+          begin
+            Determinator::Tracking.start!(:sidekiq)
+            yield
+          rescue => ex
+            error = true
+            raise
+          ensure
+            Determinator::Tracking.finish!(queue: queue, error: !!error)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/determinator/tracking/tracker.rb
+++ b/lib/determinator/tracking/tracker.rb
@@ -28,7 +28,8 @@ module Determinator
           time: request_time,
           error: error,
           attributes: attributes,
-          determinations: determinations
+          determinations: determinations,
+          context: Determinator::Tracking.context
         )
       end
     end

--- a/lib/determinator/tracking/tracker.rb
+++ b/lib/determinator/tracking/tracker.rb
@@ -9,7 +9,7 @@ module Determinator
       def initialize(type)
         @determinations = []
         @type = type
-        @start = Time.now
+        @start = now
       end
 
       def track(id, guid, feature, determination)
@@ -22,7 +22,7 @@ module Determinator
       end
 
       def finish!(error:, **attributes)
-        request_time = Time.now - @start
+        request_time = now - @start
         Determinator::Tracking::Request.new(
           type: type,
           time: request_time,
@@ -31,6 +31,12 @@ module Determinator
           determinations: determinations,
           context: Determinator::Tracking.context
         )
+      end
+
+      private
+
+      def now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     end
   end

--- a/lib/determinator/tracking/tracker.rb
+++ b/lib/determinator/tracking/tracker.rb
@@ -1,0 +1,36 @@
+require 'determinator/tracking/determination'
+require 'determinator/tracking/request'
+
+module Determinator
+  module Tracking
+    class Tracker
+      attr_reader :type, :determinations
+
+      def initialize(type)
+        @determinations = []
+        @type = type
+        @start = Time.now
+      end
+
+      def track(id, guid, feature, determination)
+        determinations << Determinator::Tracking::Determination.new(
+          id: id,
+          guid: guid,
+          feature_id: feature.identifier,
+          determination: determination
+        )
+      end
+
+      def finish!(error:, **attributes)
+        request_time = Time.now - @start
+        Determinator::Tracking::Request.new(
+          type: type,
+          time: request_time,
+          error: error,
+          attributes: attributes,
+          determinations: determinations
+        )
+      end
+    end
+  end
+end

--- a/spec/determinator/tracking/rack/middleware_spec.rb
+++ b/spec/determinator/tracking/rack/middleware_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'determinator/tracking/rack/middleware'
+
+describe Determinator::Tracking::Rack::Middleware do
+  let(:status) { 200 }
+  let(:headers) { {} }
+  let(:response) { 'foo' }
+  let(:app) { double(call: [status, headers, response]) }
+  let(:env) { double }
+  let(:subject) { described_class.new(app) }
+
+  describe '#call' do
+    it 'returns the status, headers and response' do
+      expect(subject.call(env)).to eq([status, headers, response])
+    end
+    context 'when reporting is enabled' do
+      before do
+        $_test_request = nil
+        Determinator::Tracking.on_request{ |r| $_test_request = r }
+      end
+
+      after do
+        $_test_request = nil
+        Determinator::Tracking.clear_on_request!
+      end
+
+      it 'reports a request' do
+        expect{ subject.call(env) }.to change{ $_test_request }
+          .from(nil).to instance_of(Determinator::Tracking::Request)
+      end
+
+      it 'sets the error to false' do
+        subject.call(env)
+        expect($_test_request.error).to eq(false)
+      end
+
+      it 'sets the status' do
+        subject.call(env)
+        expect($_test_request.attributes[:status]).to eq(status)
+      end
+
+      context 'when the request errors' do
+        before do
+          allow(app).to receive(:call).and_raise
+        end
+
+        it 'sets the error to true' do
+          subject.call(env) rescue nil
+          expect($_test_request.error).to eq(true)
+        end
+
+        it 'raises the error' do
+          expect { subject.call(env) }.to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/determinator/tracking/rack/middleware_spec.rb
+++ b/spec/determinator/tracking/rack/middleware_spec.rb
@@ -21,7 +21,7 @@ describe Determinator::Tracking::Rack::Middleware do
 
       after do
         $_test_request = nil
-        Determinator::Tracking.clear_on_request!
+        Determinator::Tracking.clear_hooks!
       end
 
       it 'reports a request' do

--- a/spec/determinator/tracking/rack/middleware_spec.rb
+++ b/spec/determinator/tracking/rack/middleware_spec.rb
@@ -15,42 +15,44 @@ describe Determinator::Tracking::Rack::Middleware do
     end
     context 'when reporting is enabled' do
       before do
-        $_test_request = nil
-        Determinator::Tracking.on_request{ |r| $_test_request = r }
+        @test_request = nil
+        Determinator::Tracking.on_request { |r| @test_request = r }
       end
 
       after do
-        $_test_request = nil
+        @test_request = nil
         Determinator::Tracking.clear_hooks!
       end
 
       it 'reports a request' do
-        expect{ subject.call(env) }.to change{ $_test_request }
+        expect{ subject.call(env) }.to change{ @test_request }
           .from(nil).to instance_of(Determinator::Tracking::Request)
       end
 
       it 'sets the error to false' do
         subject.call(env)
-        expect($_test_request.error).to eq(false)
+        expect(@test_request.error).to eq(false)
       end
 
       it 'sets the status' do
         subject.call(env)
-        expect($_test_request.attributes[:status]).to eq(status)
+        expect(@test_request.attributes[:status]).to eq(status)
       end
 
       context 'when the request errors' do
+        let(:error) { StandardError.new }
+
         before do
-          allow(app).to receive(:call).and_raise
+          allow(app).to receive(:call).and_raise(error)
         end
 
         it 'sets the error to true' do
           subject.call(env) rescue nil
-          expect($_test_request.error).to eq(true)
+          expect(@test_request.error).to eq(true)
         end
 
         it 'raises the error' do
-          expect { subject.call(env) }.to raise_error
+          expect { subject.call(env) }.to raise_error(error)
         end
       end
     end

--- a/spec/determinator/tracking/sidekiq/middleware_spec.rb
+++ b/spec/determinator/tracking/sidekiq/middleware_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+require 'sidekiq/testing'
+require 'determinator/tracking/sidekiq/middleware'
+
+Sidekiq::Testing.server_middleware do |chain|
+  chain.add Determinator::Tracking::Sidekiq::Middleware
+end
+Sidekiq::Testing.inline!
+
+class TestWorker
+  include Sidekiq::Worker
+
+  def perform(arg)
+    raise 'test error' if arg == 'error'
+  end
+end
+
+describe Determinator::Tracking::Sidekiq::Middleware do
+  after do
+    Sidekiq::Worker.clear_all
+  end
+
+  describe '#call' do
+    # it 'returns the status, headers and response' do
+    #   expect(subject.call(env)).to eq([status, headers, response])
+    # end
+
+    context 'when reporting is enabled' do
+      before do
+        @test_request = nil
+        Determinator::Tracking.on_request { |r| @test_request = r }
+      end
+
+      after do
+        @test_request = nil
+        Determinator::Tracking.clear_hooks!
+      end
+
+      it 'reports a request' do
+        expect{ TestWorker.perform_async('foo') }.to change{ @test_request }
+          .from(nil).to instance_of(Determinator::Tracking::Request)
+      end
+
+      it 'sets the error to false' do
+        TestWorker.perform_async('foo')
+        expect(@test_request.error).to eq(false)
+      end
+
+      it 'sets the status' do
+        TestWorker.perform_async('foo')
+        expect(@test_request.attributes[:queue]).to eq('default')
+      end
+
+      context 'when the request errors' do
+        it 'sets the error to true' do
+          TestWorker.perform_async('error') rescue nil
+          expect(@test_request.error).to eq(true)
+        end
+
+        it 'raises the error' do
+          expect { TestWorker.perform_async('error') }.to raise_error('test error')
+        end
+      end
+    end
+  end
+end

--- a/spec/determinator/tracking/tracker_spec.rb
+++ b/spec/determinator/tracking/tracker_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require 'determinator/tracking/tracker'
+
+describe Determinator::Tracking::Tracker do
+  let(:type) { :test }
+  subject{ described_class.new(type) }
+
+  describe '#track' do
+    let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
+    let(:perform) { subject.track(123, 'abc', feature, 'A') }
+
+    it 'enqueues a determination' do
+      expect{ perform }.to change{ subject.determinations.length }.by(1)
+    end
+
+    it 'sets the correct parameters' do
+      expect{ perform }.to change{ subject.determinations.first }
+        .from(nil)
+        .to(Determinator::Tracking::Determination.new(id: 123, guid: 'abc', feature_id: 'test_feature', determination: 'A'))
+    end
+  end
+
+  describe '#finish!' do
+    let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
+    let(:perform) { subject.finish!(error: true, foo: :bar) }
+
+    before do
+      subject.track(123, 'abc', feature, 'A')
+    end
+
+    it 'returns a request' do
+      expect(perform).to be_a(Determinator::Tracking::Request)
+    end
+
+    specify { expect(perform.type).to eq(:test) }
+    specify { expect(perform.time).to be_a(Float) }
+    specify { expect(perform.error).to eq(true) }
+    specify { expect(perform.attributes).to eq({foo: :bar}) }
+    specify { expect(perform.determinations.length).to eq(1) }
+  end
+end

--- a/spec/determinator/tracking/tracker_spec.rb
+++ b/spec/determinator/tracking/tracker_spec.rb
@@ -10,7 +10,7 @@ describe Determinator::Tracking::Tracker do
     let(:perform) { subject.track(123, 'abc', feature, 'A') }
 
     it 'enqueues a determination' do
-      expect{ perform }.to change{ subject.determinations.length }.by(1)
+      expect { perform }.to change { subject.determinations.length }.by(1)
     end
 
     it 'sets the correct parameters' do

--- a/spec/determinator/tracking_spec.rb
+++ b/spec/determinator/tracking_spec.rb
@@ -72,13 +72,29 @@ describe Determinator::Tracking do
         end
 
         after do
-          described_class.clear_on_request!
+          described_class.clear_hooks!
         end
 
         it 'calls the reporter' do
           expect{ described_class.finish!(error: false, foo: :bar) }.to change{ $_test_request }
             .from(nil)
             .to(instance_of(Determinator::Tracking::Request))
+        end
+      end
+
+      context 'when context is enabled' do
+        before do
+          described_class.get_context do
+            Determinator::Tracking::Context.new(request_id: 'abc')
+          end
+        end
+
+        after do
+          described_class.clear_hooks!
+        end
+
+        it 'sets the context' do
+          expect(described_class.finish!(error: false, foo: :bar).context.request_id).to eq('abc')
         end
       end
     end

--- a/spec/determinator/tracking_spec.rb
+++ b/spec/determinator/tracking_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+require 'determinator/tracking'
+
+describe Determinator::Tracking do
+  after do
+    described_class.clear!
+  end
+
+  describe '.instance' do
+    context 'not started' do
+      specify { expect(described_class.instance).to be_nil }
+    end
+
+    context 'started' do
+      before do
+        described_class.start!(:test)
+      end
+
+      specify { expect(described_class.instance).to be_a(Determinator::Tracking::Tracker) }
+    end
+  end
+
+  describe '.start' do
+    it 'returns a tracker' do
+      expect(described_class.start!(:test)).to be_a(Determinator::Tracking::Tracker)
+    end
+
+    it 'sets the type' do
+      expect(described_class.start!(:test).type).to eq(:test)
+    end
+
+    it 'sets the instance' do
+      expect { described_class.start!(:test) }.to change{ described_class.instance }.from(nil)
+    end
+  end
+
+  describe '.finish!' do
+    context 'when not started' do
+      it 'returns false' do
+        expect(described_class.finish!(error: true) ).to eq(false)
+      end
+    end
+
+    context 'when started' do
+      let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
+
+      before do
+        described_class.start!(:test)
+        described_class.track(123, 'abc', feature, 'A')
+      end
+
+      it 'returns a request' do
+        expect(described_class.finish!(error: false, foo: :bar)).to be_a(Determinator::Tracking::Request)
+      end
+
+      it 'sets the error status' do
+        expect(described_class.finish!(error: true, foo: :bar).error).to eq(true)
+      end
+
+      it 'sets the type' do
+        expect(described_class.finish!(error: false, foo: :bar).type).to eq(:test)
+      end
+
+      it 'sets the attributes' do
+        expect(described_class.finish!(error: false, foo: :bar).attributes).to eq({foo: :bar})
+      end
+
+      context 'when reporting is enabled' do
+        before do
+          $_test_request = nil
+          described_class.on_request{ |r| $_test_request = r }
+        end
+
+        after do
+          described_class.clear_on_request!
+        end
+
+        it 'calls the reporter' do
+          expect{ described_class.finish!(error: false, foo: :bar) }.to change{ $_test_request }
+            .from(nil)
+            .to(instance_of(Determinator::Tracking::Request))
+        end
+      end
+    end
+  end
+end

--- a/spec/determinator_spec.rb
+++ b/spec/determinator_spec.rb
@@ -22,12 +22,12 @@ describe Determinator do
   end
 
   describe '::on_determination and ::notice_determination' do
-    it 'sets the determination callback' do
-      id = 'id'
-      guid = 'guid'
-      feature = FactoryGirl.create(:feature)
-      determination = 'variant'
+    let(:id) { 'id' }
+    let(:guid) { 'guid' }
+    let(:determination) { 'variant' }
+    let(:feature) { FactoryGirl.create(:feature) }
 
+    it 'sets the determination callback' do
       determiantion_notified = false
 
       described_class.on_determination do |i, g, f, d|
@@ -38,6 +38,11 @@ describe Determinator do
 
       described_class.notice_determination(id, guid, feature, determination)
       expect(determiantion_notified).to be true
+    end
+
+    it 'notice_determination calls the tracker' do
+      expect(Determinator::Tracking).to receive(:track)
+      described_class.notice_determination(id, guid, feature, determination)
     end
   end
 end


### PR DESCRIPTION
This adds a Rack middleware that collects all the determinations made during a request; and provides a hook to report them, along with request metrics (time spent, response status, error).

This will enabled enhanced logging for debugging purposes, and allow us to correlate request metrics with specific flags / experiment conditions.