### PR TITLE
bump version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.4.0
 
 Feature:
 - Add tracker middleware

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.3.1'
+  VERSION = '2.4.0'
 end


### PR DESCRIPTION
substational functionality was introduced with determinator-tracking, hence the minor version bump (as I'd like people to read the release notes!)