### PR TITLE
return MissingResponse rather than nil to match standard behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.4.1
+
+Bug fix:
+- Update "fake" retrievers to match behaviour introduced in `v2.3.1` when a feature is missing
+
 # 2.4.0
 
 Feature:

--- a/lib/determinator/retrieve/in_memory_retriever.rb
+++ b/lib/determinator/retrieve/in_memory_retriever.rb
@@ -10,7 +10,7 @@ module Determinator
 
       # @param name [string,symbol] The name of the feature to retrieve
       def retrieve(name)
-        @features[name.to_s]
+        @features.fetch(name.to_s, MissingResponse.new)
       end
 
       # @param feature [Determinator::Feature] The feature to store

--- a/lib/determinator/retrieve/null_retriever.rb
+++ b/lib/determinator/retrieve/null_retriever.rb
@@ -10,6 +10,7 @@ module Determinator
       # The Control class will assume a nil return from this method
       # means the feature doesn't exist, so in turn will return `false`.
       def retrieve(_)
+        MissingResponse.new
       end
     end
   end

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end

--- a/spec/determinator/retrieve/null_retriever_spec.rb
+++ b/spec/determinator/retrieve/null_retriever_spec.rb
@@ -8,7 +8,7 @@ describe Determinator::Retrieve::NullRetriever do
 
   describe '#retrieve' do
     it 'should just return nil' do
-      expect(subject.retrieve(anything)).to be_nil
+      expect(subject.retrieve(anything)).to match an_instance_of(Determinator::MissingResponse)
     end
   end
 


### PR DESCRIPTION
## Why?

- For tests we use `Determinator::Retrieve::InMemoryRetriever` to allow simple setting of features in test contexts
- `InMemoryRetriever` (and `NullRetriever`) both currently return `nil` rather than `MissingResponse`, the later being what the regular retrievers return
- This triggered an error in local development where code that was expecting a missing feature to be `nil` rather than `MissingResponse`

## What?

- `Determinator::Retrieve::InMemoryRetriever` returns a `MissingResponse` when a feature is not present
- `Determinator::Retrieve::NullRetriever` always returns a `MissingResponse`