### PR TITLE
Add endpoint tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+Feature:
+- Add endpoint information to tracking request
+
+Bug fix:
+- Make tracking request "start" attribute an actual time
+
 # 2.4.1
 
 Bug fix:

--- a/README.md
+++ b/README.md
@@ -289,11 +289,16 @@ end
 require 'determinator/tracking'
 
 Determinator::Tracking.on_request do |r|
-  Rails.logger.info("tag=determinator_request type=#{r.type} request_time=#{r.time} error=#{r.error?} response_status=#{r.attributes[:status]} sidekiq_queue=#{r.attributes[:queue]}")
+  Rails.logger.info("tag=determinator_request endpoint=#{r.endpoint} type=#{r.type} request_time=#{r.time} error=#{r.error?} response_status=#{r.attributes[:status]} sidekiq_queue=#{r.attributes[:queue]}")
   r.determinations.each do |d|
     Rails.logger.info("tag=determination id=#{d.id} guid=#{d.guid} flag=#{d.feature_id} result=#{d.determination}")
   end
 end
+
+# The library sets the "endpoint" with information about the request or sidekiq job. If you
+# have environment variables that further identify the service, e.g. ENV['APP_NAME'],
+# you can configure the tracker to prepend it to the endpoint:
+Determinator::Tracking.endpoint_env_vars = ['APP_NAME']
 
 # If using an APM, you can provide trace information on the request by providing a get_context hook: e.g.
 
@@ -310,7 +315,7 @@ Determinator::Tracking.get_context do
 end
 ```
 
-NOTE: this is implemented by keeping the list of requests in a per-request thread-local variable, which means that determinations will only be tracked on the main thread.
+NOTE: tracking is implemented by keeping the list of requests in a per-request thread-local variable, which means that determinations will only be tracked on the main thread.
 
 If your application is spinning out worker threads, you should make the determinations in the main thread if possible; or collect them from your worker threads and track them in the main thread with
 ```

--- a/README.md
+++ b/README.md
@@ -315,9 +315,7 @@ Determinator::Tracking.get_context do
 end
 ```
 
-NOTE: tracking is implemented by keeping the list of requests in a per-request thread-local variable, which means that determinations will only be tracked on the main thread.
-
-If your application is spinning out worker threads, you should make the determinations in the main thread if possible; or collect them from your worker threads and track them in the main thread with
+NOTE: determinations will only be recorded on the threads where Determinator::Tracking is initialised via the middleware. If offloading work away from these thread (for example, by spinning up new threads within a Rack request or a Sidekiq worker), make the determinations before, and pass them through to the new threads; or, if it's not possible, collect them manually and track them in the request's thread with
 ```
 Determinator::Tracking.track(id, guid, feature, determination)
 ```

--- a/lib/determinator/tracking.rb
+++ b/lib/determinator/tracking.rb
@@ -12,9 +12,9 @@ module Determinator
         Thread.current[:determinator_tracker] = Tracker.new(type)
       end
 
-      def finish!(error:, **attributes)
+      def finish!(endpoint:, error:, **attributes)
         return false unless started?
-        request = instance.finish!(error: error, **attributes)
+        request = instance.finish!(endpoint: endpoint, error: error, **attributes)
         clear!
         report(request)
         request

--- a/lib/determinator/tracking.rb
+++ b/lib/determinator/tracking.rb
@@ -4,6 +4,8 @@ require 'determinator/tracking/context'
 module Determinator
   module Tracking
     class << self
+      attr_reader :endpoint_env_vars
+
       def instance
         Thread.current[:determinator_tracker]
       end
@@ -56,6 +58,16 @@ module Determinator
       def clear_hooks!
         @on_request = nil
         @get_context = nil
+      end
+
+      def endpoint_env_vars=(vars)
+        @endpoint_env_vars = Array(vars)
+      end
+
+      def collect_endpoint_info(parts)
+        endpoint = Array(Determinator::Tracking.endpoint_env_vars).map{ |v| ENV[v] }
+        endpoint += Array(parts)
+        endpoint.reject{ |p| p.nil? || p == ''}.join(' ')
       end
     end
   end

--- a/lib/determinator/tracking/rack/middleware.rb
+++ b/lib/determinator/tracking/rack/middleware.rb
@@ -16,7 +16,23 @@ module Determinator
           error = true
           raise
         ensure
-          Determinator::Tracking.finish!(status: status, error: !!error)
+          Determinator::Tracking.finish!(
+            status: status,
+            error: !!error,
+            endpoint: extract_endpoint(env)
+          )
+        end
+
+        private
+
+        def extract_endpoint(env)
+          if params = env['action_dispatch.request.path_parameters']
+            [params[:controller], params[:action]].join('#')
+          else
+            [env['REQUEST_METHOD'], env['PATH_INFO'] || env['REQUEST_URI']].join(' ')
+          end
+        rescue
+          env['PATH_INFO']
         end
       end
     end

--- a/lib/determinator/tracking/rack/middleware.rb
+++ b/lib/determinator/tracking/rack/middleware.rb
@@ -26,11 +26,12 @@ module Determinator
         private
 
         def extract_endpoint(env)
-          if params = env['action_dispatch.request.path_parameters']
-            [params[:controller], params[:action]].join('#')
+          parts = if params = env['action_dispatch.request.path_parameters']
+            [[params[:controller], params[:action]].join('#')]
           else
-            [env['REQUEST_METHOD'], env['PATH_INFO'] || env['REQUEST_URI']].join(' ')
+            [env['REQUEST_METHOD'], env['PATH_INFO'] || env['REQUEST_URI']]
           end
+          Determinator::Tracking.collect_endpoint_info(parts)
         rescue
           env['PATH_INFO']
         end

--- a/lib/determinator/tracking/request.rb
+++ b/lib/determinator/tracking/request.rb
@@ -1,15 +1,16 @@
 module Determinator
   module Tracking
     class Request
-      attr_reader :start, :type, :time, :error, :attributes, :determinations, :context
+      attr_reader :start, :type, :endpoint, :time, :error, :attributes, :determinations, :context
 
-      def initialize(start:, type:, time:, error:, attributes:, determinations:, context: nil)
+      def initialize(start:, type:, endpoint:, time:, error:, attributes:, determinations:, context: nil)
         @start = start
         @type = type
         @time = time
         @error = error
         @attributes = attributes
         @determinations = determinations
+        @endpoint = endpoint
         @context = context
       end
 

--- a/lib/determinator/tracking/sidekiq/middleware.rb
+++ b/lib/determinator/tracking/sidekiq/middleware.rb
@@ -18,7 +18,11 @@ module Determinator
             error = true
             raise
           ensure
-            Determinator::Tracking.finish!(queue: queue, error: !!error)
+            Determinator::Tracking.finish!(
+              endpoint: worker.class.name,
+              queue: queue,
+              error: !!error
+            )
           end
         end
       end

--- a/lib/determinator/tracking/sidekiq/middleware.rb
+++ b/lib/determinator/tracking/sidekiq/middleware.rb
@@ -19,7 +19,7 @@ module Determinator
             raise
           ensure
             Determinator::Tracking.finish!(
-              endpoint: worker.class.name,
+              endpoint: Determinator::Tracking.collect_endpoint_info(worker.class.name),
               queue: queue,
               error: !!error
             )

--- a/lib/determinator/tracking/tracker.rb
+++ b/lib/determinator/tracking/tracker.rb
@@ -21,12 +21,13 @@ module Determinator
         )
       end
 
-      def finish!(error:, **attributes)
+      def finish!(endpoint:, error:, **attributes)
         request_time = now - @start
         Determinator::Tracking::Request.new(
           start: @start,
           type: type,
           time: request_time,
+          endpoint: endpoint,
           error: error,
           attributes: attributes,
           determinations: determinations,

--- a/lib/determinator/tracking/tracker.rb
+++ b/lib/determinator/tracking/tracker.rb
@@ -9,7 +9,8 @@ module Determinator
       def initialize(type)
         @determinations = []
         @type = type
-        @start = now
+        @monotonic_start = now
+        @start = Time.now
       end
 
       def track(id, guid, feature, determination)
@@ -22,7 +23,7 @@ module Determinator
       end
 
       def finish!(endpoint:, error:, **attributes)
-        request_time = now - @start
+        request_time = now - @monotonic_start
         Determinator::Tracking::Request.new(
           start: @start,
           type: type,

--- a/spec/determinator/tracking/rack/middleware_spec.rb
+++ b/spec/determinator/tracking/rack/middleware_spec.rb
@@ -55,6 +55,23 @@ describe Determinator::Tracking::Rack::Middleware do
         end
       end
 
+      context 'with endpoint_env_vars' do
+        before do
+          Determinator::Tracking.endpoint_env_vars = ['__DETERMINATOR_TEST_ENV_VAR']
+          ENV['__DETERMINATOR_TEST_ENV_VAR'] = 'foo'
+        end
+
+        after do
+          Determinator::Tracking.endpoint_env_vars = nil
+          ENV.delete('__DETERMINATOR_TEST_ENV_VAR')
+        end
+
+        it 'adds the info from env' do
+          subject.call(env)
+          expect(@test_request.endpoint).to eq('foo GET /test')
+        end
+      end
+
       context 'when the request errors' do
         let(:error) { StandardError.new }
 

--- a/spec/determinator/tracking/sidekiq/middleware_spec.rb
+++ b/spec/determinator/tracking/sidekiq/middleware_spec.rb
@@ -51,6 +51,11 @@ describe Determinator::Tracking::Sidekiq::Middleware do
         expect(@test_request.attributes[:queue]).to eq('default')
       end
 
+      it 'sets the endpoint' do
+        TestWorker.perform_async('foo')
+        expect(@test_request.endpoint).to eq('TestWorker')
+      end
+
       context 'when the request errors' do
         it 'sets the error to true' do
           TestWorker.perform_async('error') rescue nil

--- a/spec/determinator/tracking/sidekiq/middleware_spec.rb
+++ b/spec/determinator/tracking/sidekiq/middleware_spec.rb
@@ -56,6 +56,23 @@ describe Determinator::Tracking::Sidekiq::Middleware do
         expect(@test_request.endpoint).to eq('TestWorker')
       end
 
+      context 'with endpoint_env_vars' do
+        before do
+          Determinator::Tracking.endpoint_env_vars = ['__DETERMINATOR_TEST_ENV_VAR']
+          ENV['__DETERMINATOR_TEST_ENV_VAR'] = 'foo'
+        end
+
+        after do
+          Determinator::Tracking.endpoint_env_vars = nil
+          ENV.delete('__DETERMINATOR_TEST_ENV_VAR')
+        end
+
+        it 'adds the info from env' do
+          TestWorker.perform_async('foo')
+          expect(@test_request.endpoint).to eq('foo TestWorker')
+        end
+      end
+
       context 'when the request errors' do
         it 'sets the error to true' do
           TestWorker.perform_async('error') rescue nil

--- a/spec/determinator/tracking/tracker_spec.rb
+++ b/spec/determinator/tracking/tracker_spec.rb
@@ -23,9 +23,11 @@ describe Determinator::Tracking::Tracker do
   describe '#finish!' do
     let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
     let(:perform) { subject.finish!(endpoint: 'test', error: true, foo: :bar) }
+    let(:time)    { Time.now }
 
     before do
       allow(Process).to receive(:clock_gettime).and_return(1.0, 3.0)
+      allow(Time).to receive(:now).and_return(time)
       subject.track(123, 'abc', feature, 'A')
     end
 
@@ -33,7 +35,7 @@ describe Determinator::Tracking::Tracker do
       expect(perform).to be_a(Determinator::Tracking::Request)
     end
 
-    specify { expect(perform.start).to eq(1.0)}
+    specify { expect(perform.start).to eq(time)}
     specify { expect(perform.type).to eq(:test) }
     specify { expect(perform.endpoint).to eq('test') }
     specify { expect(perform.time).to eq(2.0) }

--- a/spec/determinator/tracking/tracker_spec.rb
+++ b/spec/determinator/tracking/tracker_spec.rb
@@ -22,7 +22,7 @@ describe Determinator::Tracking::Tracker do
 
   describe '#finish!' do
     let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
-    let(:perform) { subject.finish!(error: true, foo: :bar) }
+    let(:perform) { subject.finish!(endpoint: 'test', error: true, foo: :bar) }
 
     before do
       allow(Process).to receive(:clock_gettime).and_return(1.0, 3.0)
@@ -35,6 +35,7 @@ describe Determinator::Tracking::Tracker do
 
     specify { expect(perform.start).to eq(1.0)}
     specify { expect(perform.type).to eq(:test) }
+    specify { expect(perform.endpoint).to eq('test') }
     specify { expect(perform.time).to eq(2.0) }
     specify { expect(perform.error).to eq(true) }
     specify { expect(perform.attributes).to eq({foo: :bar}) }

--- a/spec/determinator/tracking_spec.rb
+++ b/spec/determinator/tracking_spec.rb
@@ -37,7 +37,7 @@ describe Determinator::Tracking do
   describe '.finish!' do
     context 'when not started' do
       it 'returns false' do
-        expect(described_class.finish!(error: true) ).to eq(false)
+        expect(described_class.finish!(endpoint: 'test', error: true) ).to eq(false)
       end
     end
 
@@ -50,19 +50,23 @@ describe Determinator::Tracking do
       end
 
       it 'returns a request' do
-        expect(described_class.finish!(error: false, foo: :bar)).to be_a(Determinator::Tracking::Request)
+        expect(described_class.finish!(endpoint: 'test', error: false, foo: :bar)).to be_a(Determinator::Tracking::Request)
       end
 
       it 'sets the error status' do
-        expect(described_class.finish!(error: true, foo: :bar).error).to eq(true)
+        expect(described_class.finish!(endpoint: 'test', error: true, foo: :bar).error).to eq(true)
       end
 
       it 'sets the type' do
-        expect(described_class.finish!(error: false, foo: :bar).type).to eq(:test)
+        expect(described_class.finish!(endpoint: 'test', error: false, foo: :bar).type).to eq(:test)
+      end
+
+      it 'sets the endpoint' do
+        expect(described_class.finish!(endpoint: 'test', error: false, foo: :bar).endpoint).to eq('test')
       end
 
       it 'sets the attributes' do
-        expect(described_class.finish!(error: false, foo: :bar).attributes).to eq({foo: :bar})
+        expect(described_class.finish!(endpoint: 'test', error: false, foo: :bar).attributes).to eq({foo: :bar})
       end
 
       context 'when reporting is enabled' do
@@ -76,7 +80,7 @@ describe Determinator::Tracking do
         end
 
         it 'calls the reporter' do
-          expect{ described_class.finish!(error: false, foo: :bar) }.to change{ $_test_request }
+          expect{ described_class.finish!(endpoint: 'test', error: false, foo: :bar) }.to change{ $_test_request }
             .from(nil)
             .to(instance_of(Determinator::Tracking::Request))
         end
@@ -94,7 +98,7 @@ describe Determinator::Tracking do
         end
 
         it 'sets the context' do
-          expect(described_class.finish!(error: false, foo: :bar).context.request_id).to eq('abc')
+          expect(described_class.finish!(endpoint: 'test', error: false, foo: :bar).context.request_id).to eq('abc')
         end
       end
     end


### PR DESCRIPTION
As an additional piece of information in the tracked requests, we add the `endpoint` - for Rack requests, if possible, Rails controller and action, or HTTP method and request path; for Sidekiq requests, the name of the job.

In addition, this changes `Determinator::Tracking::Request#start` to be the request start time (instead of the monotonic start time, which is platform-specific).