### PR TITLE
Add sinatra.route and remove path info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.4.3
+
+Feature:
+- Add Sinatra endpoint tracking
+
+Bug fix:
+- Remove endpoint tracking of PATH_INFO
+
 # 2.4.2
 
 Feature:

--- a/lib/determinator/tracking/rack/middleware.rb
+++ b/lib/determinator/tracking/rack/middleware.rb
@@ -27,9 +27,11 @@ module Determinator
 
         def extract_endpoint(env)
           parts = if params = env['action_dispatch.request.path_parameters']
-            [[params[:controller], params[:action]].join('#')]
+            [env['REQUEST_METHOD'], [params[:controller], params[:action]].join('#')]
+          elsif env['sinatra.route']
+            [env['sinatra.route']]
           else
-            [env['REQUEST_METHOD'], env['PATH_INFO'] || env['REQUEST_URI']]
+            [env['REQUEST_METHOD']]
           end
           Determinator::Tracking.collect_endpoint_info(parts)
         rescue

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.4.2'
+  VERSION = '2.4.3'
 end

--- a/spec/determinator/tracking/rack/middleware_spec.rb
+++ b/spec/determinator/tracking/rack/middleware_spec.rb
@@ -41,7 +41,7 @@ describe Determinator::Tracking::Rack::Middleware do
 
       it 'sets the endpoint' do
         subject.call(env)
-        expect(@test_request.endpoint).to eq('GET /test')
+        expect(@test_request.endpoint).to eq('GET')
       end
 
       context 'with a rails request' do
@@ -51,7 +51,18 @@ describe Determinator::Tracking::Rack::Middleware do
 
         it 'sets the endpoint using controller info' do
           subject.call(env)
-          expect(@test_request.endpoint).to eq('foo#test')
+          expect(@test_request.endpoint).to eq('GET foo#test')
+        end
+      end
+
+      context 'with a sinatra request' do
+        let(:env) do
+          super().merge('sinatra.route' => 'POST /foo/bar' )
+        end
+
+        it 'sets the endpoint using controller info' do
+          subject.call(env)
+          expect(@test_request.endpoint).to eq('POST /foo/bar')
         end
       end
 
@@ -68,7 +79,7 @@ describe Determinator::Tracking::Rack::Middleware do
 
         it 'adds the info from env' do
           subject.call(env)
-          expect(@test_request.endpoint).to eq('foo GET /test')
+          expect(@test_request.endpoint).to eq('foo GET')
         end
       end
 


### PR DESCRIPTION
Use `sinatra.route`, if present, for tracking endpoint.

Also, removes `PATH_INFO` / `REQUEST_URI`: since the objective of the endpoint is to be able to aggregate calls for the same code path, getting the full url is not useful, as it's likely to contain path parameters.