### PR TITLE
Count repeated determinations in tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.4.4
+
+Bug fix:
+- Count repeated determinations instead of tracking separately
+
 # 2.4.3
 
 Feature:

--- a/lib/determinator/tracking/determination.rb
+++ b/lib/determinator/tracking/determination.rb
@@ -13,6 +13,12 @@ module Determinator
       def ==(other)
         id == other.id && guid == other.guid && feature_id == other.feature_id && determination == other.determination
       end
+
+      alias eql? ==
+
+      def hash
+        [id, guid, feature_id, determination].hash
+      end
     end
   end
 end

--- a/lib/determinator/tracking/tracker.rb
+++ b/lib/determinator/tracking/tracker.rb
@@ -7,19 +7,21 @@ module Determinator
       attr_reader :type, :determinations
 
       def initialize(type)
-        @determinations = []
+        @determinations = Hash.new(0)
         @type = type
         @monotonic_start = now
         @start = Time.now
       end
 
       def track(id, guid, feature, determination)
-        determinations << Determinator::Tracking::Determination.new(
-          id: id,
-          guid: guid,
-          feature_id: feature.identifier,
-          determination: determination
-        )
+        determinations[
+          Determinator::Tracking::Determination.new(
+            id: id,
+            guid: guid,
+            feature_id: feature.identifier,
+            determination: determination
+          )
+        ] += 1
       end
 
       def finish!(endpoint:, error:, **attributes)

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.4.3'
+  VERSION = '2.4.4'
 end

--- a/spec/determinator/tracking/tracker_spec.rb
+++ b/spec/determinator/tracking/tracker_spec.rb
@@ -8,15 +8,30 @@ describe Determinator::Tracking::Tracker do
   describe '#track' do
     let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
     let(:perform) { subject.track(123, 'abc', feature, 'A') }
+    let(:determination) { Determinator::Tracking::Determination.new(id: 123, guid: 'abc', feature_id: 'test_feature', determination: 'A') }
 
     it 'enqueues a determination' do
       expect { perform }.to change { subject.determinations.length }.by(1)
     end
 
     it 'sets the correct parameters' do
-      expect{ perform }.to change{ subject.determinations.first }
+      expect{ perform }.to change{ subject.determinations.keys.first }
         .from(nil)
-        .to(Determinator::Tracking::Determination.new(id: 123, guid: 'abc', feature_id: 'test_feature', determination: 'A'))
+        .to(determination)
+    end
+
+    context 'when determination is performed twice' do
+      let(:perform) { 2.times { subject.track(123, 'abc', feature, 'A') } }
+
+      it 'enqueues a determination' do
+        expect { perform }.to change { subject.determinations.length }.by(1)
+      end
+
+      it 'sets the correct parameters' do
+      expect{ perform }.to change{ subject.determinations[determination] }
+        .from(0)
+        .to(2)
+      end
     end
   end
 


### PR DESCRIPTION
Some endpoints have a lot of repeated calls to the same determinations. This compacts the internal list by keeping track of the repetitions, instead of adding an item each time.