### PR TITLE
Allow passing feature for determinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.5.2
+
+Feature:
+- Add structured_bucket to Feature
+- Add `#retrieve` method to the Control
+- Add optional `feature` argument to `feature_flag_on?` and `which_variant`, to reuse an existing feature
+
 # 2.5.1
 
 Feature:

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -34,7 +34,7 @@ module Determinator
     # @raise [ArgumentError] When the arguments given to this method aren't ever going to produce a useful response
     # @return [true,false] Whether the feature is on (true) or off (false) for this actor
     def feature_flag_on?(name, id: nil, guid: nil, properties: {}, feature: nil)
-      determinate_and_notice(name, id: id, guid: guid, properties: properties) do |feature|
+      determinate_and_notice(name, id: id, guid: guid, properties: properties, feature: feature) do |feature|
         feature.feature_flag?
       end
     end
@@ -49,7 +49,7 @@ module Determinator
     # @raise [ArgumentError] When the arguments given to this method aren't ever going to produce a useful response
     # @return [false,String] Returns false, if the actor is not in this experiment, or otherwise the variant name.
     def which_variant(name, id: nil, guid: nil, properties: {}, feature: nil)
-      determinate_and_notice(name, id: id, guid: guid, properties: properties, feature: nil) do |feature|
+      determinate_and_notice(name, id: id, guid: guid, properties: properties, feature: feature) do |feature|
         feature.experiment?
       end
     end

--- a/lib/determinator/feature.rb
+++ b/lib/determinator/feature.rb
@@ -3,9 +3,9 @@ module Determinator
   #
   # @attr_reader [nil,Hash<String,Integer>] variants The variants for this experiment, with the name of the variant as the key and the weight as the value. Will be nil for non-experiments.
   class Feature
-    attr_reader :name, :identifier, :bucket_type, :variants, :target_groups, :fixed_determinations, :active, :winning_variant
+    attr_reader :name, :identifier, :bucket_type, :structured_bucket, :variants, :target_groups, :fixed_determinations, :active, :winning_variant
 
-    def initialize(name:, identifier:, bucket_type:, target_groups:, fixed_determinations: [], variants: {}, overrides: {}, active: false, winning_variant: nil)
+    def initialize(name:, identifier:, bucket_type:, target_groups:, structured_bucket: nil, fixed_determinations: [], variants: {}, overrides: {}, active: false, winning_variant: nil)
       @name = name.to_s
       @identifier = identifier.to_s
       @variants = variants
@@ -14,6 +14,7 @@ module Determinator
       @winning_variant = parse_outcome(winning_variant, allow_exclusion: false)
       @active = active
       @bucket_type = bucket_type.to_sym
+      @structured_bucket = structured_bucket
 
       # To prevent confusion between actor id data types
       @overrides = overrides.each_with_object({}) do |(identifier, outcome), hash|
@@ -34,6 +35,11 @@ module Determinator
     # @return [true,false] Is this feature a feature flag?
     def feature_flag?
       variants.empty?
+    end
+
+    # @return [true,false] Is this feature using structured identification?
+    def structured?
+      !!structured_bucket && !structured_bucket.empty?
     end
 
     # Is this feature overridden for the given actor id?

--- a/lib/determinator/serializers/json.rb
+++ b/lib/determinator/serializers/json.rb
@@ -15,6 +15,7 @@ module Determinator
             name:                 obj['name'],
             identifier:           obj['identifier'],
             bucket_type:          obj['bucket_type'],
+            structured_bucket:    obj['structured_bucket'],
             active:               (obj['active'] === true),
             target_groups:        obj['target_groups'],
             fixed_determinations: obj['fixed_determinations'].to_a,

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.5.1'
+  VERSION = '2.5.2'
 end

--- a/spec/determinator/feature_spec.rb
+++ b/spec/determinator/feature_spec.rb
@@ -49,6 +49,28 @@ describe Determinator::Feature do
     end
   end
 
+  describe '#structured?' do
+    subject { feature.structured? }
+
+    context 'when feature is not structured' do
+      let(:feature) { FactoryGirl.create(:feature) }
+
+      it { should eq false }
+
+      context 'when structured_bucket is an empty string' do
+        let(:feature) { FactoryGirl.create(:feature, structured_bucket: '') }
+
+        it { should eq false }
+      end
+    end
+
+    context 'when feature is structured' do
+      let(:feature) { FactoryGirl.create(:feature, :structured) }
+
+      it { should eq true }
+    end
+  end
+
   describe 'when a fixed determination is present' do
     let(:instance) { FactoryGirl.create(:experiment, fixed_determinations: [fixed_determination]) }
 

--- a/spec/determinator/retrieve/http_retreiver_spec.rb
+++ b/spec/determinator/retrieve/http_retreiver_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Determinator::Retrieve::HttpRetriever do
       name: "Feature one",
       identifier: "feature",
       bucket_type: "id",
+      structured_bucket: "request.customer.guid",
       target_groups: [{
         rollout: 65536,
         constraints: {}

--- a/spec/factories/features.rb
+++ b/spec/factories/features.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence :name
     identifier { name }
     bucket_type :guid
+    structured_bucket nil
     active false
 
     # Not an experiment by default
@@ -23,6 +24,10 @@ FactoryGirl.define do
 
     trait :active do
       active true
+    end
+
+    trait :structured do
+      structured_bucket 'request.customer.guid'
     end
 
     factory :experiment, class: Determinator::Feature do


### PR DESCRIPTION
Adds `structured_path` to the Feature object, to be used for "context objects". And adds an optional `feature` argument to the determination methods. This allows the context object library to obtain information from the feature first, and then use the Control for determination, avoiding fetching the feature twice (and not relying on the retrieval cache to be present to avoid that).