### PR TITLE
Return early if fixed_determinations missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.5.3
+
+Bug fix:
+- Avoid errors when updating the gem and using persistent cache resulting in null fixed_determinations
+
 # 2.5.2
 
 Feature:

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -174,6 +174,8 @@ module Determinator
     end
 
     def choose_fixed_determination(feature, properties)
+      return unless feature.fixed_determinations
+
       # Keys and values must be strings
       normalised_properties = normalise_properties(properties)
 

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.5.2'
+  VERSION = '2.5.3'
 end


### PR DESCRIPTION
If an app uses caching, it might still have `nil` for `fixed_determinations` when the gem is updated. This adds a check to ensure this doesn't cause an error.