### PR TITLE
Apply app_version logic to request.app_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.5.4
+
+Bug fix:
+- Apply app_version logic to structured request.app_version too
+
 # 2.5.3
 
 Bug fix:

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -228,6 +228,7 @@ module Determinator
     def matches_requirements?(scope, required, present)
       case scope
         when "app_version" then has_any_app_version?(required, present)
+        when "request.app_version" then has_any_app_version?(required, present)
         else has_any?(required, present)
       end
     end

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.5.3'
+  VERSION = '2.5.4'
 end


### PR DESCRIPTION
Structured determinations pass in `request.app_version`, so the version logic should be applied to that as well.