### PR TITLE
XPT-1976: Feature cache no longer optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.6.0
 
-Breaking bug fix:
+Interface change:
 - A `feature_cache` is now required to use Determinator. See the `examples/determinator-rails/config/initializers/determinator.rb` for a quick start.
 
 # 2.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.6.0
+
+Breaking bug fix:
+- A `feature_cache` is now required to use Determinator. See the `examples/determinator-rails/config/initializers/determinator.rb` for a quick start.
+
 # 2.5.4
 
 Bug fix:

--- a/lib/determinator.rb
+++ b/lib/determinator.rb
@@ -15,10 +15,10 @@ module Determinator
   class << self
     attr_reader :feature_cache, :retrieval
     # @param :retrieval [Determinator::Retrieve::Routemaster] A retrieval instance for Features
+    # @param :feature_cache [#call] a caching proc, accepting a feature name, which will return the named feature or yield (and store) if not available
     # @param :errors [#call, nil] a proc, accepting an error, which will be called with any errors which occur while determinating
     # @param :missing_feature [#call, nil] a proc, accepting a feature name, which will be called any time a feature is requested but isn't available
-    # @param :feature_cache [#call] a caching proc, accepting a feature name, which will return the named feature or yield (and store) if not available
-    def configure(retrieval:, errors: nil, missing_feature: nil, feature_cache:)
+    def configure(retrieval:, feature_cache:, errors: nil, missing_feature: nil)
       self.on_error(&errors) if errors
       self.on_missing_feature(&missing_feature) if missing_feature
       @feature_cache = feature_cache

--- a/lib/determinator.rb
+++ b/lib/determinator.rb
@@ -17,11 +17,11 @@ module Determinator
     # @param :retrieval [Determinator::Retrieve::Routemaster] A retrieval instance for Features
     # @param :errors [#call, nil] a proc, accepting an error, which will be called with any errors which occur while determinating
     # @param :missing_feature [#call, nil] a proc, accepting a feature name, which will be called any time a feature is requested but isn't available
-    # @param :feature_cache [#call, nil] a caching proc, accepting a feature name, which will return the named feature or yield (and store) if not available
-    def configure(retrieval:, errors: nil, missing_feature: nil, feature_cache: nil)
+    # @param :feature_cache [#call] a caching proc, accepting a feature name, which will return the named feature or yield (and store) if not available
+    def configure(retrieval:, errors: nil, missing_feature: nil, feature_cache:)
       self.on_error(&errors) if errors
       self.on_missing_feature(&missing_feature) if missing_feature
-      @feature_cache = feature_cache if feature_cache.respond_to?(:call)
+      @feature_cache = feature_cache
       @retrieval = retrieval
       @instance = Control.new(retrieval: retrieval)
     end

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.5.4'
+  VERSION = '2.6.0'
 end

--- a/lib/rspec/determinator.rb
+++ b/lib/rspec/determinator.rb
@@ -3,6 +3,9 @@ require_relative '../determinator/retrieve/in_memory_retriever'
 
 module RSpec
   module Determinator
+
+    DO_NOT_USE_IN_PRODUCTION_CODE_NULL_FEATURE_CACHE = -> (name, &block) { block.call(name) }
+
     def self.included(by)
       by.extend(DSL)
 
@@ -12,10 +15,10 @@ module RSpec
         old_retriever = ::Determinator.instance.retrieval
         begin
           fake_retriever.clear!
-          ::Determinator.configure(retrieval: fake_retriever)
+          ::Determinator.configure(retrieval: fake_retriever, feature_cache: DO_NOT_USE_IN_PRODUCTION_CODE_NULL_FEATURE_CACHE)
           example.run
         ensure
-          ::Determinator.configure(retrieval: old_retriever)
+          ::Determinator.configure(retrieval: old_retriever, feature_cache: DO_NOT_USE_IN_PRODUCTION_CODE_NULL_FEATURE_CACHE)
         end
       end
     end

--- a/spec/rspec/determinator_spec.rb
+++ b/spec/rspec/determinator_spec.rb
@@ -2,7 +2,7 @@ require 'rspec/determinator'
 
 # Determinator config is always done outside tests, this
 # emulates that.
-Determinator.configure(retrieval: nil)
+Determinator.configure(retrieval: nil, feature_cache: RSpec::Determinator::DO_NOT_USE_IN_PRODUCTION_CODE_NULL_FEATURE_CACHE)
 
 describe RSpec::Determinator, :determinator_support do
   subject(:determinator) { Determinator.instance }


### PR DESCRIPTION
Without a feature cache Determinator will make direct calls to actor tracking every time a feature that doesn't exist is referenced.

This requirement will break code which incorrectly doesn't have one configured.