### PR TITLE
Long overdue move to FactoryBot

### DIFF
--- a/determinator.gemspec
+++ b/determinator.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "guard-rspec", "~> 4.7"
-  spec.add_development_dependency "factory_girl", "~> 4.8"
+  spec.add_development_dependency "factory_bot", "~> 4.8"
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency "sidekiq"
+  spec.add_development_dependency 'sidekiq'
 end

--- a/spec/determinator/cache/fetch_wrapper_spec.rb
+++ b/spec/determinator/cache/fetch_wrapper_spec.rb
@@ -3,7 +3,7 @@ require 'active_support/cache'
 
 RSpec.describe Determinator::Cache::FetchWrapper do
   let(:described_instance) { described_class.new(*caches) }
-  let(:feature) { FactoryGirl.create(:feature) }
+  let(:feature) { FactoryBot.create(:feature) }
   subject(:described_method) do
     described_instance.call(feature.name){ retrieval_response }
   end

--- a/spec/determinator/explainer_spec.rb
+++ b/spec/determinator/explainer_spec.rb
@@ -17,7 +17,7 @@ describe Determinator::Explainer do
     end
 
     context 'with logs' do
-      let(:feature) { FactoryGirl.build(:feature) }
+      let(:feature) { FactoryBot.build(:feature) }
       let(:log_statement) { instance.log(:start, { feature: feature }) }
       let(:perform) { instance.explain { log_statement } }
 
@@ -32,7 +32,7 @@ describe Determinator::Explainer do
   end
 
   describe 'log' do
-    let(:feature) { FactoryGirl.build(:feature) }
+    let(:feature) { FactoryBot.build(:feature) }
     let(:perform) { instance.log(:start, { feature: feature }) }
 
     before do

--- a/spec/determinator/feature_spec.rb
+++ b/spec/determinator/feature_spec.rb
@@ -5,13 +5,13 @@ describe Determinator::Feature do
     subject(:method_call) { instance.experiment? }
 
     context 'when the feature is an experiment' do
-      let(:instance) { FactoryGirl.create(:experiment) }
+      let(:instance) { FactoryBot.create(:experiment) }
 
       it { should eq true }
     end
 
     context 'when the feature is not an experiment' do
-      let(:instance) { FactoryGirl.create(:feature) }
+      let(:instance) { FactoryBot.create(:feature) }
 
       it { should eq false }
     end
@@ -21,13 +21,13 @@ describe Determinator::Feature do
     subject(:method_call) { instance.feature_flag? }
 
     context 'when the feature is an experiment' do
-      let(:instance) { FactoryGirl.create(:experiment) }
+      let(:instance) { FactoryBot.create(:experiment) }
 
       it { should eq false }
     end
 
     context 'when the feature is not an experiment' do
-      let(:instance) { FactoryGirl.create(:feature) }
+      let(:instance) { FactoryBot.create(:feature) }
 
       it { should eq true }
     end
@@ -37,13 +37,13 @@ describe Determinator::Feature do
     subject { feature.active? }
 
     context 'when feature is active' do
-      let(:feature) { FactoryGirl.create(:feature, :active) }
+      let(:feature) { FactoryBot.create(:feature, :active) }
 
       it { should be_truthy }
     end
 
     context 'when feature is inactive' do
-      let(:feature) { FactoryGirl.create(:feature) }
+      let(:feature) { FactoryBot.create(:feature) }
 
       it { should be_falsey }
     end
@@ -53,26 +53,26 @@ describe Determinator::Feature do
     subject { feature.structured? }
 
     context 'when feature is not structured' do
-      let(:feature) { FactoryGirl.create(:feature) }
+      let(:feature) { FactoryBot.create(:feature) }
 
       it { should eq false }
 
       context 'when structured_bucket is an empty string' do
-        let(:feature) { FactoryGirl.create(:feature, structured_bucket: '') }
+        let(:feature) { FactoryBot.create(:feature, structured_bucket: '') }
 
         it { should eq false }
       end
     end
 
     context 'when feature is structured' do
-      let(:feature) { FactoryGirl.create(:feature, :structured) }
+      let(:feature) { FactoryBot.create(:feature, :structured) }
 
       it { should eq true }
     end
   end
 
   describe 'when a fixed determination is present' do
-    let(:instance) { FactoryGirl.create(:experiment, fixed_determinations: [fixed_determination]) }
+    let(:instance) { FactoryBot.create(:experiment, fixed_determinations: [fixed_determination]) }
 
     context 'when the variant is not present in the variants' do
       let(:fixed_determination) { {'feature_on' => true, 'variant' => 'c', 'constraints' => {}} }

--- a/spec/determinator/tracking/tracker_spec.rb
+++ b/spec/determinator/tracking/tracker_spec.rb
@@ -6,7 +6,7 @@ describe Determinator::Tracking::Tracker do
   subject{ described_class.new(type) }
 
   describe '#track' do
-    let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
+    let(:feature) { FactoryBot.build(:feature, name: 'test_feature') }
     let(:perform) { subject.track(123, 'abc', feature, 'A') }
     let(:determination) { Determinator::Tracking::Determination.new(id: 123, guid: 'abc', feature_id: 'test_feature', determination: 'A') }
 
@@ -36,7 +36,7 @@ describe Determinator::Tracking::Tracker do
   end
 
   describe '#finish!' do
-    let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
+    let(:feature) { FactoryBot.build(:feature, name: 'test_feature') }
     let(:perform) { subject.finish!(endpoint: 'test', error: true, foo: :bar) }
     let(:time)    { Time.now }
 

--- a/spec/determinator/tracking_spec.rb
+++ b/spec/determinator/tracking_spec.rb
@@ -42,7 +42,7 @@ describe Determinator::Tracking do
     end
 
     context 'when started' do
-      let(:feature) { FactoryGirl.build(:feature, name: 'test_feature') }
+      let(:feature) { FactoryBot.build(:feature, name: 'test_feature') }
 
       before do
         described_class.start!(:test)

--- a/spec/determinator_spec.rb
+++ b/spec/determinator_spec.rb
@@ -25,7 +25,7 @@ describe Determinator do
     let(:id) { 'id' }
     let(:guid) { 'guid' }
     let(:determination) { 'variant' }
-    let(:feature) { FactoryGirl.create(:feature) }
+    let(:feature) { FactoryBot.create(:feature) }
 
     it 'sets the determination callback' do
       determiantion_notified = false

--- a/spec/factories/features.rb
+++ b/spec/factories/features.rb
@@ -1,15 +1,15 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :feature, class: Determinator::Feature do
     sequence :name
     identifier { name }
-    bucket_type :guid
-    structured_bucket nil
-    active false
+    bucket_type { :guid }
+    structured_bucket { nil }
+    active { false }
 
     # Not an experiment by default
-    variants Hash.new
+    variants { Hash.new }
 
-    overrides Hash.new
+    overrides { Hash.new }
     target_groups { [
       create(:target_group,
         rollout: rollout,
@@ -18,20 +18,20 @@ FactoryGirl.define do
     ] }
 
     transient do
-      rollout 32_768
-      constraints Hash.new
+      rollout { 32_768 }
+      constraints { Hash.new }
     end
 
     trait :active do
-      active true
+      active { true }
     end
 
     trait :structured do
-      structured_bucket 'request.customer.guid'
+      structured_bucket { 'request.customer.guid' }
     end
 
     factory :experiment, class: Determinator::Feature do
-      variants Hash[[['a', 1], ['b', 2]]]
+      variants { Hash[[['a', 1], ['b', 2]]] }
     end
   end
 end

--- a/spec/factories/target_groups.rb
+++ b/spec/factories/target_groups.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :target_group, class: Determinator::TargetGroup do
     sequence :name
-    rollout 65_536
-    constraints Hash.new('property' => 'value')
+    rollout { 65_536 }
+    constraints { Hash.new('property' => 'value') }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 Dir["./spec/support/**/*.rb"].each {|f| require f}
 require 'determinator'
-require 'factory_girl'
+require 'factory_bot'
 require 'rspec/its'
 
 RSpec.configure do |config|
@@ -9,9 +9,9 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   initialize_with { new(attributes) }
   skip_create
 end
 
-FactoryGirl.find_definitions
+FactoryBot.find_definitions


### PR DESCRIPTION
FactoryGirl renamed their gem to FactoryBot some time ago. I support this move, it's about time we changed the references in this library.

Also fixed some deprecation warnings from the v5 FactoryBot bump (which I'm sure we'll be doing soon).