### PR TITLE
Ensure git username is added

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      run: |
+        git config user.email "rooci@deliveroo.co.uk"
+        git config user.name "Determinator Release Github Action"
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:


### PR DESCRIPTION
Oh no.

One more PR to ensure we have the git username/email that the tag push requires.