### PR TITLE
Ensure constraints are arrays of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.7.0
+
+⚠️ This release includes breaking changes ⚠️
+
+Interface change:
+- Constraints which are not arrays of strings are no longer accepted; if present, the library returns false and logs an error.
+
 # 2.6.0
 
 Interface change:

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -219,6 +219,9 @@ module Determinator
     end
 
     def matches_constraints(normalised_properties, constraints)
+      unless constraints.all?{ |k, v| k.is_a?(String) && v.all?{ |vv| vv.is_a?(String) } }
+        raise "Constraints must by arrays of strings"
+      end
       constraints.reduce(true) do |fit, (scope, *required)|
         present = [*normalised_properties[scope]]
         fit && matches_requirements?(scope, required, present)

--- a/lib/determinator/feature.rb
+++ b/lib/determinator/feature.rb
@@ -84,7 +84,7 @@ module Determinator
       TargetGroup.new(
         name: target_group['name'],
         rollout: target_group['rollout'].to_i,
-        constraints: parse_constraints(constraints)
+        constraints: constraints
       )
 
     # Invalid target groups are ignored
@@ -111,17 +111,11 @@ module Determinator
         name: fixed_determination['name'],
         feature_on: fixed_determination['feature_on'],
         variant: variant,
-        constraints: parse_constraints(constraints)
+        constraints: constraints
       )
     # Invalid fixed determinations are ignored
     rescue
       nil
-    end
-
-    def parse_constraints(constraints)
-      constraints.each_with_object({}) do |(key, value), hash|
-        hash[key.to_s] = [*value].map(&:to_s)
-      end
     end
   end
 end

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.6.0'
+  VERSION = '2.7.0'
 end


### PR DESCRIPTION
Adapts the library to the [standard tests change](https://github.com/deliveroo/determinator-standard-tests/pull/13) which now requires all constraints to be an array of strings, and for the library to return an error if they aren't.