### PR TITLE
Returns false instead of throwing an error

### DIFF
--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -267,7 +267,7 @@ module Determinator
         return guid if guid.to_s != ''
 
         explainer.log(:missing_identifier, { identifier_type: 'GUID' })
-        raise ArgumentError, 'A GUID must always be given for GUID bucketed features'
+        return
       when :fallback
         identifier = (id || guid).to_s
         return identifier if identifier != ''

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -124,13 +124,9 @@ module Determinator
       # require_variant_determination?
       return true unless require_variant_determination?(feature)
 
-
-
       explainer.log(:chosen_variant) {
         variant_for(feature, indicators.variant)
       }
-    rescue ArgumentError
-      raise
 
     rescue => e
       Determinator.notice_error(e)
@@ -267,7 +263,7 @@ module Determinator
         return guid if guid.to_s != ''
 
         explainer.log(:missing_identifier, { identifier_type: 'GUID' })
-        return
+        raise ArgumentError, 'A GUID must always be given for GUID bucketed features'
       when :fallback
         identifier = (id || guid).to_s
         return identifier if identifier != ''

--- a/spec/determinator/control_spec.rb
+++ b/spec/determinator/control_spec.rb
@@ -4,7 +4,7 @@ require 'set'
 
 describe Determinator::Control do
   context "determinator-standard-tests" do
-    TESTS_WRITTEN_FOR = Gem::Dependency.new('determinator-standard-tests', '~> 1.1')
+    TESTS_WRITTEN_FOR = Gem::Dependency.new('determinator-standard-tests', '~> 1.1.4')
     STANDARDS_DIR = Pathname.new('spec/standard_cases')
 
     subject(:determinator_instance) do

--- a/spec/determinator/control_spec.rb
+++ b/spec/determinator/control_spec.rb
@@ -4,7 +4,7 @@ require 'set'
 
 describe Determinator::Control do
   context "determinator-standard-tests" do
-    TESTS_WRITTEN_FOR = Gem::Dependency.new('determinator-standard-tests', '~> 1.1.4')
+    TESTS_WRITTEN_FOR = Gem::Dependency.new('determinator-standard-tests', '~> 1.1.5')
     STANDARDS_DIR = Pathname.new('spec/standard_cases')
 
     subject(:determinator_instance) do


### PR DESCRIPTION
When guid is not supplied for a guid bucketed feature, returns false instead of throwing an error.

https://deliveroo.atlassian.net/browse/PROM-1156