### PR TITLE
RPE-691: Ignore app versions not compliant with semver specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.9.0
+
+Feature:
+- When an app_version does not comply with semantic versioning specifications (e.g.: 2021.11.05 with a trailing zero instead of the correct 2021.11.5), return false.
+
 # 2.8.0
 
 Feature:

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -245,7 +245,8 @@ module Determinator
         !v.match?(Semantic::Version::SemVerRegexp)
       end
       invalid_groups = required.flatten.select do |v|
-        !v.match?(/\d/)
+        without_operator = v.gsub(/>=|>|<=|<|~>/, '')
+        !without_operator.match?(Semantic::Version::SemVerRegexp)
       end
 
       return false if (invalid_properties + invalid_groups).any?

--- a/lib/determinator/control.rb
+++ b/lib/determinator/control.rb
@@ -241,7 +241,8 @@ module Determinator
         !v.match?(Semantic::Version::SemVerRegexp)
       end
       invalid_groups = required.flatten.select do |v|
-        without_operator = v.gsub(/>=|>|<=|<|~>/, '')
+        version_sections = v.split(/(\d(.+)?)/, 2)
+        without_operator = version_sections[1]&.strip || ''
         !without_operator.match?(Semantic::Version::SemVerRegexp)
       end
 

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.8.0'
+  VERSION = '2.9.0'
 end

--- a/spec/determinator/control_spec.rb
+++ b/spec/determinator/control_spec.rb
@@ -4,7 +4,7 @@ require 'set'
 
 describe Determinator::Control do
   context "determinator-standard-tests" do
-    TESTS_WRITTEN_FOR = Gem::Dependency.new('determinator-standard-tests', '~> 1.1')
+    TESTS_WRITTEN_FOR = Gem::Dependency.new('determinator-standard-tests', '~> 1.1.6')
     STANDARDS_DIR = Pathname.new('spec/standard_cases')
 
     subject(:determinator_instance) do


### PR DESCRIPTION
Ticket: https://deliveroo.atlassian.net/browse/RPE-691

Related spec updates: https://github.com/deliveroo/determinator-standard-tests/pull/15

The Determinator gem raises an exception on `app_version`s with the following format: 2021.11.05. It should just return false on that determination if the input is invalid.

According to the semantic versioning specs none of the components of the version number should have any trailing zeros. So the above version should be 2021.11.5.

Setting the above non-compliant app version caused the following issue:
Sentry: https://sentry.io/organizations/deliveroo/issues/2813035755/?project=1460916&query=is%3Aunresolved