### PR TITLE
Increases the gem version to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.7.2
+
+Feature:
+- When a GUID bucketed feature is misconfigured, handle the error and return false.
+
 # 2.7.1
 
 Feature:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.7.2
+# 2.8.0
 
 Feature:
 - When a GUID bucketed feature is misconfigured, handle the error and return false.

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.7.2'
+  VERSION = '2.8.0'
 end

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.7.1'
+  VERSION = '2.7.2'
 end


### PR DESCRIPTION
Increases the gem version for the [implementation](https://github.com/deliveroo/determinator/pull/111) of `when no guid is supplied for a guid bucketed feature, returns false instead of throwing an error.`
https://deliveroo.atlassian.net/browse/PROM-1156 