### PR TITLE
Add callback to Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.9.1
+
+Feature:
+- Add `callback` argument to Control, allowing custom logic to notice the determination.
+
 # 2.9.0
 
 Feature:

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.9.0'
+  VERSION = '2.9.1'
 end


### PR DESCRIPTION
Adds a `callback` argument to the Control, which is called after the determination. 

There is already a `on_determination` static method on the Determinator module. However:
- it's missing the parameters argument, and it's not easy to add that without breaking backwards compatibility
- since it's global on the Determinator module, it's not useful to compare determinations done from different controls.

By adding this method to the Control, it allows us to more easily compare the behaviour of different implementations. 