### PR TITLE
Ignore fixed determination variant if blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.9.2
+
+Bug fix:
+- Fix parsing fixed determinations when the variant is an empty string
+
 # 2.9.1
 
 Feature:

--- a/lib/determinator/feature.rb
+++ b/lib/determinator/feature.rb
@@ -100,10 +100,10 @@ module Determinator
       return fixed_determination if fixed_determination.is_a? FixedDetermination
 
       variant = fixed_determination['variant']
-      return nil if variant && !variants.keys.include?(variant)
+      return nil if variant.present? && !variants.keys.include?(variant)
 
       # if a variant is present the fixed determination should always be on
-      return nil if variant && !fixed_determination['feature_on']
+      return nil if variant.present? && !fixed_determination['feature_on']
 
       constraints = fixed_determination['constraints'].to_h
 

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.9.1'
+  VERSION = '2.9.2'
 end

--- a/spec/determinator/feature_spec.rb
+++ b/spec/determinator/feature_spec.rb
@@ -89,5 +89,13 @@ describe Determinator::Feature do
         expect(instance.fixed_determinations).to be_empty
       end
     end
+
+    context 'when the variant is blank' do
+      let(:fixed_determination) { {'feature_on' => true, 'variant' => '', 'constraints' => {}} }
+
+      it 'should not be ignored' do
+        expect(instance.fixed_determinations.first.feature_on).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Depending on the serializer generating the feature, the fixed determination variant might be an empty string. When that's the case, it should be considered as empty.