### PR TITLE
Add mutex to the cache wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.9.3
+
+Feature:
+- Add optional `feature` argument to `feature_flag_on?` and `which_variant` methods of ActorControl, to reuse an existing feature.
+- Add mutex to synchronise access to caches in Cache::FetchWrapper.
+
 # 2.9.2
 
 Bug fix:

--- a/lib/determinator/actor_control.rb
+++ b/lib/determinator/actor_control.rb
@@ -24,18 +24,14 @@ module Determinator
     end
 
     # @see Determinator::Control#feature_flag_on?
-    def feature_flag_on?(name, properties: {})
+    def feature_flag_on?(name, properties: {}, feature: nil)
       controller.feature_flag_on?(
         name,
         id: id,
         guid: guid,
-        properties: default_properties.merge(properties)
+        properties: default_properties.merge(properties),
+        feature: feature
       )
-    end
-
-    # @see Determinator::Control#retrieve
-    def retrieve(name)
-      controller.retrieve(name)
     end
 
     def inspect

--- a/lib/determinator/actor_control.rb
+++ b/lib/determinator/actor_control.rb
@@ -14,12 +14,13 @@ module Determinator
     end
 
     # @see Determinator::Control#which_variant
-    def which_variant(name, properties: {})
+    def which_variant(name, properties: {}, feature: nil)
       controller.which_variant(
         name,
         id: id,
         guid: guid,
-        properties: default_properties.merge(properties)
+        properties: default_properties.merge(properties),
+        feature: feature
       )
     end
 

--- a/lib/determinator/actor_control.rb
+++ b/lib/determinator/actor_control.rb
@@ -33,6 +33,11 @@ module Determinator
       )
     end
 
+    # @see Determinator::Control#retrieve
+    def retrieve(name)
+      controller.retrieve(name)
+    end
+
     def inspect
       "#<Determinator::ActorControl id=#{id.inspect} guid=#{guid.inspect}>"
     end

--- a/lib/determinator/cache/fetch_wrapper.rb
+++ b/lib/determinator/cache/fetch_wrapper.rb
@@ -13,24 +13,24 @@ module Determinator
       # Call walks through each cache, returning a value if the item exists in
       # any cache, otherwise popularing each cache with the value of yield.
       def call(feature_name)
+        value = read_and_upfill(feature_name)
+
+        # if the value is missing and we cache it, return the missing response
+        return value if value.is_a?(MissingResponse) && @cache_missing
+
+        #otherwise only return the non nil/notice_missing_feature value
+        return value if !value.nil? && !(value.is_a?(MissingResponse) && !@cache_missing)
+
+        value_to_write = yield
+        return value_to_write if value_to_write.is_a?(ErrorResponse)
+
         @mutex.synchronize do
-          value = read_and_upfill(feature_name)
-
-          # if the value is missing and we cache it, return the missing response
-          return value if value.is_a?(MissingResponse) && @cache_missing
-
-          #otherwise only return the non nil/notice_missing_feature value
-          return value if !value.nil? && !(value.is_a?(MissingResponse) && !@cache_missing)
-
-          value_to_write = yield
-          return value_to_write if value_to_write.is_a?(ErrorResponse)
-
           @caches.each do |cache|
             cache.write(key(feature_name), value_to_write)
           end
-
-          return value_to_write
         end
+
+        return value_to_write
       end
 
       def expire(feature_name)
@@ -53,16 +53,20 @@ module Determinator
       # @param url [String] a feature name
       # @return [Feature, MissingResponse] nil when no value is found
       def read_and_upfill(feature_name)
-        @caches.each.with_index do |cache, index|
-          if cache.exist?(key(feature_name))
-            value = cache.read(key(feature_name))
-            @caches[0...index].each do |cache|
-              cache.write(key(feature_name), value)
+        @mutex.synchronize do
+          @caches.each.with_index do |cache, index|
+            if cache.exist?(key(feature_name))
+              value = cache.read(key(feature_name))
+              @caches[0...index].each do |cache|
+                cache.write(key(feature_name), value)
+              end
+
+              return value
             end
-            return value
           end
+
+          return nil
         end
-        return nil
       end
     end
   end

--- a/lib/determinator/version.rb
+++ b/lib/determinator/version.rb
@@ -1,3 +1,3 @@
 module Determinator
-  VERSION = '2.9.2'
+  VERSION = '2.9.3'
 end


### PR DESCRIPTION
We are planning to use determinator cache wrapper from the multiple threads. Even though all the used cache stores are individually thread-safe, Determinator::Cache::FetchWrapper class isn't.