### PR TITLE
Upgrade github action setup for deployment

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,25 +1,22 @@
 name: Ruby Gem
-
 on:
   push:
     branches: [ master ]
-
 jobs:
   build:
     name: Build + Publish
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set git user
       run: |
         git config user.email "rooci@deliveroo.co.uk"
         git config user.name "Determinator Release Github Action"
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
-
+        ruby-version: '2.6'
+        bundler-cache: true
     - name: Publish to RubyGems
       run: |
         mkdir -p $HOME/.gem


### PR DESCRIPTION
Github action actions/setup-ruby@v1 is deprecated and is no longer maintained. Need to migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.

Related to https://deliveroo.atlassian.net/browse/XPT-5164.