### PR TITLE
ci:add codeowners template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Please include the (team) name of the codeowner(s) below following the syntax guidance in the github documentation for automatic peer reviewer assignment and ease to identify the owner
+# [github documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+* 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# Please include the (team) name of the codeowner(s) below following the syntax guidance in the github documentation for automatic peer reviewer assignment and ease to identify the owner
-# [github documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+* @deliveroo/experimentation-platform-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Please include the (team) name of the codeowner(s) below following the syntax guidance in the github documentation for automatic peer reviewer assignment and ease to identify the owner
 # [github documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
-* 


### PR DESCRIPTION
### Why?
 This PR has been raised by the Product Security Engineering team as no CODEOWNERS file was found in this repository. The benefit of the CODEOWNERS file is to be able to easily identify who owns this code and enables automatic peer reviewer assignment when a PR is raised.


---

## What you need to do (How to review)?
Currently the CODEOWNERS is blank.
1. Please edit the file to add in the name of the codeowner(s)
2. Merge the PR

 If this PR was raised by mistake and a CODEOWNERS file is not needed, feel free to close this PR.

---
### Further info

Guidance on the syntax is included in the [github CODEOWNERS Documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

### [JIRA: PSC-824](https://deliveroo.atlassian.net/browse/PSC-824?atlOrigin=eyJpIjoiNDdlZjE0MDA2YzczNGQ0N2EwMjc4NWM3MjQ1NGRkYTgiLCJwIjoiaiJ9)

